### PR TITLE
Feat/83 update clinic endpoint

### DIFF
--- a/libs/core-rest-api/adapters/src/controllers/api/api.module.ts
+++ b/libs/core-rest-api/adapters/src/controllers/api/api.module.ts
@@ -15,6 +15,8 @@ import { CreateClinicController } from './use-cases/clinic/create-clinic/create-
 import { NestjsCreateClinicService } from './use-cases/clinic/create-clinic/nestjs-create-clinic.service';
 import { DeleteClinicController } from './use-cases/clinic/delete-clinic/delete-clinic.controller';
 import { NestjsDeleteClinicService } from './use-cases/clinic/delete-clinic/nestjs-delete-clinic.service';
+import { NestjsUpdateClinicService } from './use-cases/clinic/update-clinic/nestjs-update-clinic.service';
+import { UpdateClinicController } from './use-cases/clinic/update-clinic/update-clinic.controller';
 import { AuthenticatePsychologistController } from './use-cases/psychologist/authenticate-psychologist/authenticate-psychologist.controller';
 import { NestjsAuthenticatePsychologistService } from './use-cases/psychologist/authenticate-psychologist/nestjs-authenticate-psychologist.service';
 import { CreatePsychologistController } from './use-cases/psychologist/create-psychologist/create-psychologist.controller';
@@ -35,21 +37,23 @@ import { NestjsUpdatePsychologistService } from './use-cases/psychologist/update
     CryptographyModule,
   ],
   controllers: [
-    CreatePsychologistController,
     AuthenticatePsychologistController,
-    CreateClinicController,
-    DeleteClinicController,
+    CreatePsychologistController,
     UpdatePsychologistController,
     DeletePsychologistController,
+    CreateClinicController,
+    UpdateClinicController,
+    DeleteClinicController
   ],
   providers: [
     BcryptHasherService,
     PostgreSqlPrismaOrmService,
-    NestjsCreatePsychologistService,
     NestjsAuthenticatePsychologistService,
+    NestjsCreatePsychologistService,
     NestjsUpdatePsychologistService,
     NestjsDeletePsychologistService,
     NestjsCreateClinicService,
+    NestjsUpdateClinicService,
     NestjsDeleteClinicService
   ],
 })

--- a/libs/core-rest-api/adapters/src/controllers/api/use-cases/clinic/clinic-client.http
+++ b/libs/core-rest-api/adapters/src/controllers/api/use-cases/clinic/clinic-client.http
@@ -28,6 +28,19 @@ Authorization: Bearer {{authToken}}
 
 ####
 
+# @name update_clinic
+
+PATCH http://localhost:3333/core/clinic/8d40bb8d-fd0b-4753-83cf-87bac7b3c6e7/update HTTP/1.1
+Content-Type: application/json
+Authorization: Bearer {{authToken}}
+
+{
+  "name": "New Name Clinic"
+}
+
+
+####
+
 # @name delete_clinic
 
 DELETE http://localhost:3333/core/clinic/159b4134-9d2a-4198-98c3-ac031eb31998/delete HTTP/1.1

--- a/libs/core-rest-api/adapters/src/controllers/api/use-cases/clinic/update-clinic/dto.ts
+++ b/libs/core-rest-api/adapters/src/controllers/api/use-cases/clinic/update-clinic/dto.ts
@@ -1,0 +1,31 @@
+import { IsDate, IsOptional, IsString } from 'class-validator';
+
+export class UpdateClinicControllerDto {
+  @IsOptional()
+  @IsString()
+  name?: string;
+
+  @IsOptional()
+  @IsString()
+  psychologistId?: string;
+
+  @IsOptional()
+  @IsString()
+  address?: string | null;
+
+  @IsOptional()
+  @IsString()
+  city?: string;
+
+  @IsOptional()
+  @IsString()
+  state?: string;
+
+  @IsOptional()
+  @IsDate()
+  createdAt?: Date;
+
+  @IsOptional()
+  @IsDate()
+  updatedAt?: Date | null;
+}

--- a/libs/core-rest-api/adapters/src/controllers/api/use-cases/clinic/update-clinic/nestjs-update-clinic.service.ts
+++ b/libs/core-rest-api/adapters/src/controllers/api/use-cases/clinic/update-clinic/nestjs-update-clinic.service.ts
@@ -1,0 +1,10 @@
+import { ClinicDatabaseRepository } from '@clinicControl/core-rest-api/core/src/domains/clinic/repositories/database-repository';
+import { UpdateClinicService } from '@clinicControl/core-rest-api/core/src/domains/clinic/use-cases/update-clinic/update-clinic.service';
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class NestjsUpdateClinicService extends UpdateClinicService {
+  constructor(clinicDatabaseRepository: ClinicDatabaseRepository) {
+    super(clinicDatabaseRepository);
+  }
+}

--- a/libs/core-rest-api/adapters/src/controllers/api/use-cases/clinic/update-clinic/update-clinic.controller.ts
+++ b/libs/core-rest-api/adapters/src/controllers/api/use-cases/clinic/update-clinic/update-clinic.controller.ts
@@ -1,0 +1,41 @@
+import { BadRequestException, Body, Controller, Param, Patch } from '@nestjs/common';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+
+import { UpdateClinicDto } from '@clinicControl/core-rest-api/core/src/domains/clinic/use-cases/update-clinic/update-clinic-dto';
+import { GlobalAppHttpException } from '@clinicControl/core-rest-api/core/src/shared/errors/globalAppHttpException';
+import { UpdateClinicControllerDto } from './dto';
+import { NestjsUpdateClinicService } from './nestjs-update-clinic.service';
+
+@ApiTags('Clinic')
+@ApiBearerAuth()
+@Controller({
+  path: 'clinic',
+})
+export class UpdateClinicController {
+  constructor(private updateClinicService: NestjsUpdateClinicService) {}
+
+  @Patch(':clinicId/update')
+  async execute(
+    @Param('clinicId') clinicId: string,
+    @Body() updateClinicDto: UpdateClinicControllerDto
+  ) {
+    try {
+      const isReqBodyEmpty = Object.keys(updateClinicDto).length === 0;
+
+      if (isReqBodyEmpty) {
+        throw new BadRequestException('Must provide at least one field to update');
+      }
+
+      const clinic = {
+        id: clinicId.toString(),
+        ...updateClinicDto,
+      } as UpdateClinicDto;
+
+      await this.updateClinicService.execute(clinic);
+
+      return { message: 'Clinic updated successfully' };
+    } catch (error: unknown) {
+      throw new GlobalAppHttpException(error);
+    }
+  }
+}

--- a/libs/core-rest-api/adapters/src/controllers/api/use-cases/clinic/update-clinic/update-clinic.e2e-spec.ts
+++ b/libs/core-rest-api/adapters/src/controllers/api/use-cases/clinic/update-clinic/update-clinic.e2e-spec.ts
@@ -1,0 +1,112 @@
+import request from 'supertest';
+
+import { INestApplication } from '@nestjs/common';
+
+import { ClinicEntity } from '@clinicControl/core-rest-api/core/src/domains/clinic/entities/clinic/entity';
+import { PsychologistFactory } from '../../../../../../tests/factories/make-psychologist';
+import { setupE2ETest } from '../../../shared/utils/e2e-tests-initial-setup';
+
+describe('[E2E] - Update Clinic', () => {
+  let app: INestApplication;
+  let psychologistFactory: PsychologistFactory;
+  let clinic: ClinicEntity
+  let psychologistId: string;
+  let access_token: string;
+  let invalid_access_token: string;
+  let password: string;
+
+  beforeAll(async () => {
+    const setup = await setupE2ETest();
+    app = setup.app;
+
+    psychologistFactory = setup.psychologistFactory;
+
+    clinic = setup.clinic
+    psychologistId = setup.id;
+    password = setup.password;
+
+    access_token = setup.access_token;
+    invalid_access_token = setup.invalid_access_token;
+  });
+
+  it('[PATCH] - Should successfully update a clinic', async () => {
+    const updateInfos = {
+      name: 'New Clinic Name',
+    };
+
+    const response = await request(app.getHttpServer())
+      .patch(`/clinic/${clinic.id}/update`)
+      .set('Authorization', `Bearer ${access_token}`)
+      .send(updateInfos);
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body.message).toBe('Clinic updated successfully');
+  });
+
+  it('[PATCH] - Should return an error when trying to update a clinic without access_token', async () => {
+    const updateInfos = {
+      name: 'New Clinic Name',
+    };
+
+    const response = await request(app.getHttpServer())
+      .patch(`/clinic/${clinic.id}/update`)
+      .send(updateInfos);
+
+    expect(response.statusCode).toBe(401);
+    expect(response.body.message).toBe('Invalid JWT token');
+  });
+
+  it('[PATCH] - Should return an error when trying to update a clinic with invalid access_token', async () => {
+    const updateInfos = {
+      name: 'New Clinic Name',
+    };
+
+    const response = await request(app.getHttpServer())
+      .patch(`/clinic/${clinic.id}/update`)
+      .set('Authorization', `Bearer ${invalid_access_token}`)
+      .send(updateInfos);
+
+    expect(response.statusCode).toBe(401);
+    expect(response.body.message).toBe('Invalid JWT token');
+  });
+
+  it('[PATCH] - Should return an error when trying to update a clinic with invalid id', async () => {
+    const updateInfos = {
+      name: 'New Clinic Name',
+    };
+
+    const response = await request(app.getHttpServer())
+      .patch(`/clinic/invalid_id/update`)
+      .set('Authorization', `Bearer ${access_token}`)
+      .send(updateInfos);
+
+    expect(response.statusCode).toBe(409);
+    expect(response.body.message).toBe('clinic not found');
+  });
+
+  it('[PATCH] - Should return an error when trying to update a clinic with empty request body', async () => {
+    const updateInfos = {};
+
+    const response = await request(app.getHttpServer())
+      .patch(`/clinic/${clinic.id}/update`)
+      .set('Authorization', `Bearer ${access_token}`)
+      .send(updateInfos);
+
+    expect(response.statusCode).toBe(400);
+    expect(response.body.message).toBe('Must provide at least one field to update');
+  });
+
+  it('[PATCH] - Should return an error when trying to update a clinic with an invalid body type params', async () => {
+    const updateInfos = {
+      name: 123,
+    };
+
+    const response = await request(app.getHttpServer())
+      .patch(`/clinic/${clinic.id}/update`)
+      .set('Authorization', `Bearer ${access_token}`)
+      .send(updateInfos);
+
+    expect(response.statusCode).toBe(400);
+    expect(response.body.message).toStrictEqual(['name must be a string']);
+  });
+});

--- a/libs/core-rest-api/adapters/src/controllers/api/use-cases/psychologist/update-psychologist/update-psychologist.e2e-spec.ts
+++ b/libs/core-rest-api/adapters/src/controllers/api/use-cases/psychologist/update-psychologist/update-psychologist.e2e-spec.ts
@@ -9,7 +9,7 @@ describe('[E2E] - Update Psychologist Account', () => {
   let app: INestApplication;
   let psychologistFactory: PsychologistFactory;
 
-  let id: string;
+  let psychologistId: string;
   let access_token: string;
   let invalid_access_token: string;
   let password: string;
@@ -20,7 +20,7 @@ describe('[E2E] - Update Psychologist Account', () => {
 
     psychologistFactory = setup.psychologistFactory;
 
-    id = setup.id;
+    psychologistId = setup.id;
     password = setup.password;
 
     access_token = setup.access_token;
@@ -34,7 +34,7 @@ describe('[E2E] - Update Psychologist Account', () => {
     };
 
     const response = await request(app.getHttpServer())
-      .patch(`/psychologist/${id}/update`)
+      .patch(`/psychologist/${psychologistId}/update`)
       .set('Authorization', `Bearer ${access_token}`)
       .send(updateInfos);
 
@@ -48,7 +48,7 @@ describe('[E2E] - Update Psychologist Account', () => {
     };
 
     const response = await request(app.getHttpServer())
-      .patch(`/psychologist/${id}/update`)
+      .patch(`/psychologist/${psychologistId}/update`)
       .send(updateInfos);
 
     expect(response.statusCode).toBe(401);
@@ -61,7 +61,7 @@ describe('[E2E] - Update Psychologist Account', () => {
     };
 
     const response = await request(app.getHttpServer())
-      .patch(`/psychologist/${id}/update`)
+      .patch(`/psychologist/${psychologistId}/update`)
       .set('Authorization', `Bearer ${invalid_access_token}`)
       .send(updateInfos);
 
@@ -87,7 +87,7 @@ describe('[E2E] - Update Psychologist Account', () => {
     const updateInfos = {};
 
     const response = await request(app.getHttpServer())
-      .patch(`/psychologist/${id}/update`)
+      .patch(`/psychologist/${psychologistId}/update`)
       .set('Authorization', `Bearer ${access_token}`)
       .send(updateInfos);
 
@@ -105,7 +105,7 @@ describe('[E2E] - Update Psychologist Account', () => {
     };
 
     const response = await request(app.getHttpServer())
-      .patch(`/psychologist/${id}/update`)
+      .patch(`/psychologist/${psychologistId}/update`)
       .set('Authorization', `Bearer ${access_token}`)
       .send(updateInfos);
 
@@ -119,7 +119,7 @@ describe('[E2E] - Update Psychologist Account', () => {
     };
 
     const response = await request(app.getHttpServer())
-      .patch(`/psychologist/${id}/update`)
+      .patch(`/psychologist/${psychologistId}/update`)
       .set('Authorization', `Bearer ${access_token}`)
       .send(updateInfos);
 
@@ -133,7 +133,7 @@ describe('[E2E] - Update Psychologist Account', () => {
     };
 
     const response = await request(app.getHttpServer())
-      .patch(`/psychologist/${id}/update`)
+      .patch(`/psychologist/${psychologistId}/update`)
       .set('Authorization', `Bearer ${access_token}`)
       .send(updateInfos);
 
@@ -149,7 +149,7 @@ describe('[E2E] - Update Psychologist Account', () => {
     };
 
     const response = await request(app.getHttpServer())
-      .patch(`/psychologist/${id}/update`)
+      .patch(`/psychologist/${psychologistId}/update`)
       .set('Authorization', `Bearer ${access_token}`)
       .send(updateInfos);
 


### PR DESCRIPTION
<!-- pt-BR -->

# O que foi modificado?

- Foi adicionado um novo endpoint para atualização de clínica

### Links de referência e etapas para avaliação

- Rode o seguinte comando para subir o projeto: `pnpm run core-setup --action=migrate,generate`
- Rode o seguinte comando para rodar a aplicação: `pnpm exec nx run core-rest-api:serve`
  - Verifique se não crashou a aplicação
- Agora navegue para: `libs/core-rest-api/adapters/src/controllers/api/use-cases/clinic`
- Acesse o arquivo: `clinic-client.http`
  - Agora teste todo o fluxo de update de clínica
    - Criar um usuário
    - Logar com as credenciais deste usuário
    - Criar uma clínica
    - Testar todas as possibilidades de update de clínica

### Palavras-chave

`core`, `clinic`, `update endpoint`

# Por que foi modificado?

- https://github.com/ItaloRAmaral/cliniccontrol/issues/83
