### PR TITLE
111 delete patient endpoint

### DIFF
--- a/apps/core-rest-api/http/patient-client.http
+++ b/apps/core-rest-api/http/patient-client.http
@@ -17,3 +17,9 @@ Authorization: Bearer {{authToken}}
   "clinicId": "{{$dotenv CLINIC_ID}}",
   "paymentMethod": "CREDIT_CARD"
 }
+
+### Delete a patient
+# @name delete_patient
+DELETE http://localhost:3333/core/patient/{{$dotenv PATIENT_ID}}/delete HTTP/1.1
+Content-Type: application/json
+Authorization: Bearer {{authToken}}

--- a/libs/core-rest-api/adapters/src/controllers/api/api.module.ts
+++ b/libs/core-rest-api/adapters/src/controllers/api/api.module.ts
@@ -12,18 +12,21 @@ import { PostgreSqlPrismaOrmService } from '../../database/infra/prisma/prisma.s
 import { DatabaseRepositoriesModule } from '../../database/repositories/repositories.module';
 
 import { CreateClinicController } from './use-cases/clinic/create-clinic/create-clinic.controller';
-import { NestjsCreateClinicService } from './use-cases/clinic/create-clinic/nestjs-create-clinic.service';
 import { DeleteClinicController } from './use-cases/clinic/delete-clinic/delete-clinic.controller';
-import { NestjsDeleteClinicService } from './use-cases/clinic/delete-clinic/nestjs-delete-clinic.service';
-import { NestjsUpdateClinicService } from './use-cases/clinic/update-clinic/nestjs-update-clinic.service';
 import { UpdateClinicController } from './use-cases/clinic/update-clinic/update-clinic.controller';
 import { CreatePatientController } from './use-cases/patient/create-patient/create-patient.controller';
-import { NestjsCreatePatientService } from './use-cases/patient/create-patient/nestjs-create-patient.service';
+import { DeletePatientController } from './use-cases/patient/delete-patient/delete-patient.controller';
 import { AuthenticatePsychologistController } from './use-cases/psychologist/authenticate-psychologist/authenticate-psychologist.controller';
-import { NestjsAuthenticatePsychologistService } from './use-cases/psychologist/authenticate-psychologist/nestjs-authenticate-psychologist.service';
 import { CreatePsychologistController } from './use-cases/psychologist/create-psychologist/create-psychologist.controller';
-import { NestjsCreatePsychologistService } from './use-cases/psychologist/create-psychologist/nestjs-create-psychologist.service';
 import { DeletePsychologistController } from './use-cases/psychologist/delete-psychologist/delete-psychologist.controller';
+
+import { NestjsCreateClinicService } from './use-cases/clinic/create-clinic/nestjs-create-clinic.service';
+import { NestjsDeleteClinicService } from './use-cases/clinic/delete-clinic/nestjs-delete-clinic.service';
+import { NestjsUpdateClinicService } from './use-cases/clinic/update-clinic/nestjs-update-clinic.service';
+import { NestjsCreatePatientService } from './use-cases/patient/create-patient/nestjs-create-patient.service';
+import { NestjsDeletePatientService } from './use-cases/patient/delete-patient/nestjs-delete-patient.service';
+import { NestjsAuthenticatePsychologistService } from './use-cases/psychologist/authenticate-psychologist/nestjs-authenticate-psychologist.service';
+import { NestjsCreatePsychologistService } from './use-cases/psychologist/create-psychologist/nestjs-create-psychologist.service';
 import { NestjsDeletePsychologistService } from './use-cases/psychologist/delete-psychologist/nestjs-delete-psychologist.service';
 import { NestjsUpdatePsychologistService } from './use-cases/psychologist/update-psychologist/nestjs-update-psychologist.service';
 
@@ -47,6 +50,7 @@ import { NestjsUpdatePsychologistService } from './use-cases/psychologist/update
     UpdateClinicController,
     DeleteClinicController,
     CreatePatientController,
+    DeletePatientController,
   ],
   providers: [
     BcryptHasherService,
@@ -59,6 +63,7 @@ import { NestjsUpdatePsychologistService } from './use-cases/psychologist/update
     NestjsUpdateClinicService,
     NestjsDeleteClinicService,
     NestjsCreatePatientService,
+    NestjsDeletePatientService,
   ],
 })
 export class ApiModule {}

--- a/libs/core-rest-api/adapters/src/controllers/api/use-cases/clinic/create-clinic/create-clinic.controller.ts
+++ b/libs/core-rest-api/adapters/src/controllers/api/use-cases/clinic/create-clinic/create-clinic.controller.ts
@@ -5,25 +5,22 @@ import { Body, Controller, Post } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { NestjsCreateClinicService } from './nestjs-create-clinic.service';
 
-interface createClinicResponse {
-  message: string
+interface CreateClinicResponse {
+  message: string;
 }
+
 @ApiTags('Clinic')
 @Controller({
   path: 'clinic',
 })
 export class CreateClinicController {
-  constructor(
-    private createClinicService: NestjsCreateClinicService
-  ) {}
+  constructor(private createClinicService: NestjsCreateClinicService) {}
 
   @Post('create')
-  async execute(
-    @Body() createClinicDto: CreateClinicDto
-  ): Promise<createClinicResponse>{
+  async execute(@Body() createClinicDto: CreateClinicDto): Promise<CreateClinicResponse> {
     try {
       await this.createClinicService.execute(createClinicDto);
-      return {message: 'Clinic created successfully'}
+      return { message: 'Clinic created successfully' };
     } catch (error: unknown) {
       throw new GlobalAppHttpException(error);
     }

--- a/libs/core-rest-api/adapters/src/controllers/api/use-cases/clinic/delete-clinic/delete-clinic.e2e-spec.ts
+++ b/libs/core-rest-api/adapters/src/controllers/api/use-cases/clinic/delete-clinic/delete-clinic.e2e-spec.ts
@@ -48,7 +48,7 @@ describe('[E2E] - Delete Clinic', () => {
       .delete(`/clinic/${wrongId}/delete`)
       .set('Authorization', `Bearer ${access_token}`);
 
-    expect(response.status).toBe(409);
+    expect(response.status).toBe(404);
     expect(response.body.message).toBe('clinic not found');
   });
 

--- a/libs/core-rest-api/adapters/src/controllers/api/use-cases/clinic/update-clinic/update-clinic.e2e-spec.ts
+++ b/libs/core-rest-api/adapters/src/controllers/api/use-cases/clinic/update-clinic/update-clinic.e2e-spec.ts
@@ -7,7 +7,7 @@ import { setupE2ETest } from '../../../shared/utils/e2e-tests-initial-setup';
 
 describe('[E2E] - Update Clinic', () => {
   let app: INestApplication;
-  let clinic: ClinicEntity
+  let clinic: ClinicEntity;
   let access_token: string;
   let invalid_access_token: string;
 
@@ -15,7 +15,7 @@ describe('[E2E] - Update Clinic', () => {
     const setup = await setupE2ETest();
     app = setup.app;
 
-    clinic = setup.clinic
+    clinic = setup.clinic;
 
     access_token = setup.access_token;
     invalid_access_token = setup.invalid_access_token;
@@ -72,7 +72,7 @@ describe('[E2E] - Update Clinic', () => {
       .set('Authorization', `Bearer ${access_token}`)
       .send(updateInfos);
 
-    expect(response.statusCode).toBe(409);
+    expect(response.statusCode).toBe(404);
     expect(response.body.message).toBe('clinic not found');
   });
 

--- a/libs/core-rest-api/adapters/src/controllers/api/use-cases/patient/delete-patient/delete-patient.controller.ts
+++ b/libs/core-rest-api/adapters/src/controllers/api/use-cases/patient/delete-patient/delete-patient.controller.ts
@@ -1,0 +1,36 @@
+import { Controller, Delete, Param } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { deleteMethodDocs } from './docs';
+
+import { GlobalAppHttpException } from '@clinicControl/core-rest-api/core/src/shared/errors/globalAppHttpException';
+
+import { TokenPayload } from '../../../../../auth/jwt.strategy';
+import { CurrentUser } from '../../../decorators/current-user.decorator';
+import { RouteParamsDto } from './dto';
+import { NestjsDeletePatientService } from './nestjs-delete-patient.service';
+
+@ApiTags('patient')
+@ApiBearerAuth()
+@Controller({
+  path: 'patient',
+})
+export class DeletePatientController {
+  constructor(private deletePatientService: NestjsDeletePatientService) {}
+
+  @Delete(':patientEmail/delete')
+  @ApiOperation(deleteMethodDocs)
+  async execute(
+    @Param() { patientEmail }: RouteParamsDto,
+    @CurrentUser() currentUser: TokenPayload,
+  ) {
+    try {
+      await this.deletePatientService.execute(patientEmail);
+
+      return {
+        message: 'Patient deleted successfully',
+      };
+    } catch (error: unknown) {
+      throw new GlobalAppHttpException(error);
+    }
+  }
+}

--- a/libs/core-rest-api/adapters/src/controllers/api/use-cases/patient/delete-patient/delete-patient.controller.ts
+++ b/libs/core-rest-api/adapters/src/controllers/api/use-cases/patient/delete-patient/delete-patient.controller.ts
@@ -17,14 +17,19 @@ import { NestjsDeletePatientService } from './nestjs-delete-patient.service';
 export class DeletePatientController {
   constructor(private deletePatientService: NestjsDeletePatientService) {}
 
-  @Delete(':patientEmail/delete')
+  @Delete(':patientId/delete')
   @ApiOperation(deleteMethodDocs)
   async execute(
-    @Param() { patientEmail }: RouteParamsDto,
+    @Param() { patientId }: RouteParamsDto,
     @CurrentUser() currentUser: TokenPayload,
   ) {
     try {
-      await this.deletePatientService.execute(patientEmail);
+      const deletePatientDto = {
+        patientId,
+        psychologistId: currentUser.id,
+      };
+
+      await this.deletePatientService.execute(deletePatientDto);
 
       return {
         message: 'Patient deleted successfully',

--- a/libs/core-rest-api/adapters/src/controllers/api/use-cases/patient/delete-patient/delete-patient.e2e-spec.ts
+++ b/libs/core-rest-api/adapters/src/controllers/api/use-cases/patient/delete-patient/delete-patient.e2e-spec.ts
@@ -1,0 +1,105 @@
+import { fakerPT_BR as faker } from '@faker-js/faker';
+import { INestApplication } from '@nestjs/common';
+import request from 'supertest';
+
+import { PostgreSqlPrismaOrmService } from '../../../../../database/infra/prisma/prisma.service';
+import { setupE2ETest } from '../../../shared/utils/e2e-tests-initial-setup';
+
+import { ClinicEntity } from '@clinicControl/core-rest-api/core/src/domains/clinic/entities/clinic/entity';
+import { PatientEntity } from '@clinicControl/core-rest-api/core/src/domains/patient/entities/patient/entity';
+import { PatientFactory } from '../../../../../../tests/factories/make-patient';
+import { PsychologistFactory } from '../../../../../../tests/factories/make-psychologist';
+
+describe('[E2E] - Delete Patient', async () => {
+  let prisma: PostgreSqlPrismaOrmService;
+  let app: INestApplication;
+
+  let patientFactory: PatientFactory;
+  let psychologistFactory: PsychologistFactory;
+
+  let access_token: string;
+  let invalid_access_token: string;
+
+  let patient: PatientEntity;
+  let clinic: ClinicEntity;
+
+  beforeAll(async () => {
+    const setup = await setupE2ETest();
+
+    prisma = setup.prisma;
+    app = setup.app;
+
+    patientFactory = setup.patientFactory;
+    psychologistFactory = setup.psychologistFactory;
+
+    access_token = setup.access_token;
+    invalid_access_token = setup.invalid_access_token;
+
+    clinic = setup.clinic;
+    patient = setup.patient;
+  });
+
+  it('[DELETE] - Should return an error when trying to delete a patient without access_token', async () => {
+    const response = await request(app.getHttpServer()).delete(
+      `/patient/${patient.id}/delete`,
+    );
+
+    expect(response.status).toBe(401);
+    expect(response.body.message).toBe('Invalid JWT token');
+  });
+
+  it('[DELETE] - Should return an error when trying to delete a patient with invalid access_token', async () => {
+    const response = await request(app.getHttpServer())
+      .delete(`/patient/${patient.id}/delete`)
+      .set('Authorization', `Bearer ${invalid_access_token}`);
+
+    expect(response.status).toBe(401);
+    expect(response.body.message).toBe('Invalid JWT token');
+  });
+
+  it('[DELETE] - Should throw an error when trying to delete a patient which does not belong to the psychologist', async () => {
+    const newPsychologist = await psychologistFactory.makePrismaPsychologist({
+      email: faker.internet.email(),
+    });
+
+    const newPatient = await patientFactory.makePrismaPatient({
+      psychologistId: newPsychologist.id,
+      clinicId: clinic.id,
+    });
+
+    const response = await request(app.getHttpServer())
+      .delete(`/patient/${newPatient.id}/delete`)
+      .set('Authorization', `Bearer ${access_token}`);
+
+    expect(response.status).toBe(401);
+    expect(response.body.message).toBe('this patient does not belong to you');
+  });
+
+  it('[DELETE] - Should throw an error when trying to delete a patient that does not exist', async () => {
+    const fakePatientId = faker.string.uuid();
+
+    const response = await request(app.getHttpServer())
+      .delete(`/patient/${fakePatientId}/delete`)
+      .set('Authorization', `Bearer ${access_token}`);
+
+    expect(response.status).toBe(404);
+    expect(response.body.message).toBe('patient not found');
+  });
+
+  it('[DELETE] - Should successfully delete a patient', async () => {
+    const response = await request(app.getHttpServer())
+      .delete(`/patient/${patient.id}/delete`)
+      .set('Authorization', `Bearer ${access_token}`);
+
+    const isPatientExist = await prisma.patient.findUnique({
+      where: {
+        id: patient.id,
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.message).toBe('Patient deleted successfully');
+
+    expect(isPatientExist).toBe(null);
+  });
+});

--- a/libs/core-rest-api/adapters/src/controllers/api/use-cases/patient/delete-patient/docs.ts
+++ b/libs/core-rest-api/adapters/src/controllers/api/use-cases/patient/delete-patient/docs.ts
@@ -1,0 +1,17 @@
+import { OperationObject } from '@nestjs/swagger/dist/interfaces/open-api-spec.interface';
+
+const description = `
+---
+\`Experimental\`
+---
+
+### Delete a  Patient in the system
+
+This endpoint help you to Delete a  patient.
+You must at least provide one of the following body parameters
+`;
+
+export const deleteMethodDocs: Partial<OperationObject> = {
+  summary: 'Delete a patient',
+  description,
+};

--- a/libs/core-rest-api/adapters/src/controllers/api/use-cases/patient/delete-patient/dto.ts
+++ b/libs/core-rest-api/adapters/src/controllers/api/use-cases/patient/delete-patient/dto.ts
@@ -1,6 +1,6 @@
-import { IsEmail } from 'class-validator';
+import { IsString } from 'class-validator';
 
 export class RouteParamsDto {
-  @IsEmail()
+  @IsString()
   patientId!: string;
 }

--- a/libs/core-rest-api/adapters/src/controllers/api/use-cases/patient/delete-patient/dto.ts
+++ b/libs/core-rest-api/adapters/src/controllers/api/use-cases/patient/delete-patient/dto.ts
@@ -2,5 +2,5 @@ import { IsEmail } from 'class-validator';
 
 export class RouteParamsDto {
   @IsEmail()
-  patientEmail!: string;
+  patientId!: string;
 }

--- a/libs/core-rest-api/adapters/src/controllers/api/use-cases/patient/delete-patient/dto.ts
+++ b/libs/core-rest-api/adapters/src/controllers/api/use-cases/patient/delete-patient/dto.ts
@@ -1,0 +1,6 @@
+import { IsEmail } from 'class-validator';
+
+export class RouteParamsDto {
+  @IsEmail()
+  patientEmail!: string;
+}

--- a/libs/core-rest-api/adapters/src/controllers/api/use-cases/patient/delete-patient/nestjs-delete-patient.service.ts
+++ b/libs/core-rest-api/adapters/src/controllers/api/use-cases/patient/delete-patient/nestjs-delete-patient.service.ts
@@ -1,0 +1,11 @@
+import { Injectable } from '@nestjs/common';
+
+import { PatientDatabaseRepository } from '@clinicControl/core-rest-api/core/src/domains/patient/repositories/database-repository';
+import { DeletePatientService } from '@clinicControl/core-rest-api/core/src/domains/patient/use-cases/delete-patient/delete-patient.service';
+
+@Injectable()
+export class NestjsDeletePatientService extends DeletePatientService {
+  constructor(patientDatabaseRepository: PatientDatabaseRepository) {
+    super(patientDatabaseRepository);
+  }
+}

--- a/libs/core-rest-api/adapters/src/controllers/api/use-cases/psychologist/update-psychologist/update-psychologist.e2e-spec.ts
+++ b/libs/core-rest-api/adapters/src/controllers/api/use-cases/psychologist/update-psychologist/update-psychologist.e2e-spec.ts
@@ -79,7 +79,7 @@ describe('[E2E] - Update Psychologist Account', () => {
       .set('Authorization', `Bearer ${access_token}`)
       .send(updateInfos);
 
-    expect(response.statusCode).toBe(400);
+    expect(response.statusCode).toBe(404);
     expect(response.body.message).toBe('psychologist not found');
   });
 

--- a/libs/core-rest-api/adapters/src/database/repositories/patient/postgres-prisma-orm-patient-repository.ts
+++ b/libs/core-rest-api/adapters/src/database/repositories/patient/postgres-prisma-orm-patient-repository.ts
@@ -43,10 +43,10 @@ export class PostgresqlPrismaOrmPatientRepository implements PatientDatabaseRepo
     return PostgresqlPrismaPatientMapper.toDomain(patient);
   }
 
-  async findPatientById(id: string): Promise<PatientEntity | null> {
+  async findPatientById(patientId: string): Promise<PatientEntity | null> {
     const patient = await this.postgresqlPrismaOrmService['patient'].findUnique({
       where: {
-        id: id,
+        id: patientId,
       },
     });
 
@@ -77,8 +77,8 @@ export class PostgresqlPrismaOrmPatientRepository implements PatientDatabaseRepo
     await this.postgresqlPrismaOrmService['patient'].update(toPrismaEntity);
   }
 
-  async deletePatient(email: string): Promise<void> {
-    const isPatientExists = await this.findPatientByEmail(email);
+  async deletePatient(patientId: string): Promise<void> {
+    const isPatientExists = await this.findPatientById(patientId);
 
     if (!isPatientExists) {
       throw new ConflictException(PATIENT_ERROR_MESSAGES['PATIENT_NOT_FOUND']);
@@ -86,7 +86,7 @@ export class PostgresqlPrismaOrmPatientRepository implements PatientDatabaseRepo
 
     await this.postgresqlPrismaOrmService['patient'].delete({
       where: {
-        email: email,
+        id: patientId,
       },
     });
   }

--- a/libs/core-rest-api/adapters/vite.config.ts
+++ b/libs/core-rest-api/adapters/vite.config.ts
@@ -3,13 +3,10 @@ import swc from 'unplugin-swc';
 import { defineConfig } from 'vite';
 import tsconfigPaths from 'vite-tsconfig-paths';
 
-import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
-
 export default defineConfig({
   cacheDir: '../../../node_modules/.vite/core-rest-api-adapters',
 
   plugins: [
-    nxViteTsPaths(),
     swc.vite({
       module: { type: 'es6' },
     }),

--- a/libs/core-rest-api/adapters/vitest.config.e2e.ts
+++ b/libs/core-rest-api/adapters/vitest.config.e2e.ts
@@ -2,11 +2,8 @@ import swc from 'unplugin-swc';
 import { defineConfig } from 'vite';
 import tsconfigPaths from 'vite-tsconfig-paths';
 
-import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
-
 export default defineConfig({
   plugins: [
-    nxViteTsPaths(),
     swc.vite({
       module: { type: 'es6' },
     }),

--- a/libs/core-rest-api/core/src/domains/appointment/repositories/database-in-memory-repository.ts
+++ b/libs/core-rest-api/core/src/domains/appointment/repositories/database-in-memory-repository.ts
@@ -12,16 +12,12 @@ export class InMemoryAppointmentDatabaseRepository
   private appointments: AppointmentEntity[] = [];
 
   async createSingleAppointment(
-    appointment: CreateSingleAppointmentDto
+    appointment: CreateSingleAppointmentDto,
   ): Promise<AppointmentEntity> {
-    const isAppointmentExist = await this.findSingleAppointmentByDate(
-      appointment.date
-    );
+    const isAppointmentExist = await this.findSingleAppointmentByDate(appointment.date);
 
     if (isAppointmentExist) {
-      throw new ConflictException(
-        APPOINTMENT_ERROR_MESSAGES['CONFLICTING_DATE_TIME']
-      );
+      throw new ConflictException(APPOINTMENT_ERROR_MESSAGES['CONFLICTING_DATE_TIME']);
     }
 
     const newAppointment = new AppointmentEntity(appointment);
@@ -32,22 +28,19 @@ export class InMemoryAppointmentDatabaseRepository
   }
 
   async findSingleAppointmentByDate(
-    appointmentDate: Date
+    appointmentDate: Date,
   ): Promise<AppointmentEntity | null> {
     return (
-      this.appointments.find(
-        (appointment) => appointment.date === appointmentDate
-      ) ?? null
+      this.appointments.find((appointment) => appointment.date === appointmentDate) ??
+      null
     );
   }
 
   async findSingleAppointmentById(
-    appointmentId: string
+    appointmentId: string,
   ): Promise<AppointmentEntity | null> {
     return (
-      this.appointments.find(
-        (appointment) => appointment.id === appointmentId
-      ) ?? null
+      this.appointments.find((appointment) => appointment.id === appointmentId) ?? null
     );
   }
 
@@ -56,16 +49,14 @@ export class InMemoryAppointmentDatabaseRepository
   }
 
   async updateAppointmentInfo(
-    newAppointmentInfo: UpdatedAppointmentInfoDto
+    newAppointmentInfo: UpdatedAppointmentInfoDto,
   ): Promise<void> {
     const oldAppointmentInfo = await this.findSingleAppointmentById(
-      newAppointmentInfo.id
+      newAppointmentInfo.id,
     );
 
     if (!oldAppointmentInfo) {
-      throw new ConflictException(
-        APPOINTMENT_ERROR_MESSAGES['APPOINTMENT_NOT_FOUND']
-      );
+      throw new ConflictException(APPOINTMENT_ERROR_MESSAGES['APPOINTMENT_NOT_FOUND']);
     }
 
     const appointmentIndex = this.appointments.findIndex((appointment) => {
@@ -81,20 +72,18 @@ export class InMemoryAppointmentDatabaseRepository
   }
 
   async updateAppointmentDate(
-    newAppointmentInfo: UpdatedAppointmentDateDto
+    newAppointmentInfo: UpdatedAppointmentDateDto,
   ): Promise<void> {
     const oldAppointmentInfo = await this.findSingleAppointmentById(
-      newAppointmentInfo.id
+      newAppointmentInfo.id,
     );
 
     if (!oldAppointmentInfo) {
-      throw new ConflictException(
-        APPOINTMENT_ERROR_MESSAGES['APPOINTMENT_NOT_FOUND']
-      );
+      throw new ConflictException(APPOINTMENT_ERROR_MESSAGES['APPOINTMENT_NOT_FOUND']);
     }
 
     const appointmentIndex = this.appointments.findIndex((appointment) => {
-      return (appointment.id = newAppointmentInfo.id);
+      return appointment.id === newAppointmentInfo.id;
     });
 
     const updateAppointmentDate = Object.assign(oldAppointmentInfo, {
@@ -106,18 +95,14 @@ export class InMemoryAppointmentDatabaseRepository
   }
 
   async deleteSingleAppointment(appointmentId: string): Promise<void> {
-    const isAppointmentExist = await this.findSingleAppointmentById(
-      appointmentId
-    );
+    const isAppointmentExist = await this.findSingleAppointmentById(appointmentId);
 
     if (!isAppointmentExist) {
-      throw new ConflictException(
-        APPOINTMENT_ERROR_MESSAGES['APPOINTMENT_NOT_FOUND']
-      );
+      throw new ConflictException(APPOINTMENT_ERROR_MESSAGES['APPOINTMENT_NOT_FOUND']);
     }
 
     this.appointments = this.appointments.filter(
-      (appointment) => appointment.id !== appointmentId
+      (appointment) => appointment.id !== appointmentId,
     );
   }
 }

--- a/libs/core-rest-api/core/src/domains/appointment/use-cases/delete-single-appointment/delete-single-appointment.service.ts
+++ b/libs/core-rest-api/core/src/domains/appointment/use-cases/delete-single-appointment/delete-single-appointment.service.ts
@@ -1,22 +1,16 @@
-import { ConflictException } from '@nestjs/common';
+import { NotFoundException } from '@nestjs/common';
 import { APPOINTMENT_ERROR_MESSAGES } from '../../../../shared/errors/error-messages';
 import { AppointmentDatabaseRepository } from '../../repositories/database-repository';
 
 export class DeleteSingleAppointmentService {
-  constructor(
-    private appointmentDatabaseRepository: AppointmentDatabaseRepository
-  ) {}
+  constructor(private appointmentDatabaseRepository: AppointmentDatabaseRepository) {}
 
   async execute(appointmentId: string): Promise<void> {
     const isAppointmentExists =
-      await this.appointmentDatabaseRepository.findSingleAppointmentById(
-        appointmentId
-      );
+      await this.appointmentDatabaseRepository.findSingleAppointmentById(appointmentId);
 
     if (!isAppointmentExists) {
-      throw new ConflictException(
-        APPOINTMENT_ERROR_MESSAGES['APPOINTMENT_NOT_FOUND']
-      );
+      throw new NotFoundException(APPOINTMENT_ERROR_MESSAGES['APPOINTMENT_NOT_FOUND']);
     }
 
     // Delete

--- a/libs/core-rest-api/core/src/domains/appointment/use-cases/delete-single-appointment/delete-single-appointment.spec.ts
+++ b/libs/core-rest-api/core/src/domains/appointment/use-cases/delete-single-appointment/delete-single-appointment.spec.ts
@@ -1,5 +1,5 @@
 import { fakerPT_BR as faker } from '@faker-js/faker';
-import { ConflictException } from '@nestjs/common';
+import { NotFoundException } from '@nestjs/common';
 import { randomUUID } from 'crypto';
 import { PaymentMethod } from '../../../../shared/interfaces/payments';
 import { InMemoryAppointmentDatabaseRepository } from '../../repositories/database-in-memory-repository';
@@ -29,9 +29,8 @@ describe('[appointment] Create Single Appointment Service', () => {
   });
 
   it('should delete a new appointment', async () => {
-    const createAppointment = await databaseRepository.createSingleAppointment(
-      fakeAppointment
-    );
+    const createAppointment =
+      await databaseRepository.createSingleAppointment(fakeAppointment);
     await service.execute(createAppointment.id);
     const getAppointments = await databaseRepository.getAppointments();
 
@@ -39,12 +38,11 @@ describe('[appointment] Create Single Appointment Service', () => {
   });
 
   it('should throw error if appointment does not exist', async () => {
-    const createAppointment = await databaseRepository.createSingleAppointment(
-      fakeAppointment
-    );
+    const createAppointment =
+      await databaseRepository.createSingleAppointment(fakeAppointment);
     await service.execute(createAppointment.id);
     await expect(service.execute(createAppointment.id)).rejects.toThrow(
-      ConflictException
+      NotFoundException,
     );
   });
 });

--- a/libs/core-rest-api/core/src/domains/appointment/use-cases/update-appointment-date/update-appointment-date.service.ts
+++ b/libs/core-rest-api/core/src/domains/appointment/use-cases/update-appointment-date/update-appointment-date.service.ts
@@ -1,4 +1,4 @@
-import { ConflictException } from '@nestjs/common';
+import { NotFoundException } from '@nestjs/common';
 import { plainToInstance } from 'class-transformer';
 import { APPOINTMENT_ERROR_MESSAGES } from '../../../../shared/errors/error-messages';
 import { applicationValidateOrReject } from '../../../../shared/validators/validate-or-reject';
@@ -6,32 +6,26 @@ import { AppointmentDatabaseRepository } from '../../repositories/database-repos
 import { UpdatedAppointmentDateDto } from './update-appointment-date-dto';
 
 export class UpdateAppointmentDateService {
-  constructor(
-    private appointmentDatabaseRepository: AppointmentDatabaseRepository
-  ) {}
+  constructor(private appointmentDatabaseRepository: AppointmentDatabaseRepository) {}
 
   async execute(newAppointmentInfo: UpdatedAppointmentDateDto): Promise<void> {
     // Validate props
 
     const updateAppointmentDateDtoInstance = plainToInstance(
       UpdatedAppointmentDateDto,
-      newAppointmentInfo
+      newAppointmentInfo,
     );
 
     await applicationValidateOrReject(updateAppointmentDateDtoInstance);
 
     const oldAppointmentInfo =
       await this.appointmentDatabaseRepository.findSingleAppointmentById(
-        newAppointmentInfo.id
+        newAppointmentInfo.id,
       );
     if (!oldAppointmentInfo) {
-      throw new ConflictException(
-        APPOINTMENT_ERROR_MESSAGES['APPOINTMENT_NOT_FOUND']
-      );
+      throw new NotFoundException(APPOINTMENT_ERROR_MESSAGES['APPOINTMENT_NOT_FOUND']);
     }
 
-    await this.appointmentDatabaseRepository.updateAppointmentDate(
-      newAppointmentInfo
-    );
+    await this.appointmentDatabaseRepository.updateAppointmentDate(newAppointmentInfo);
   }
 }

--- a/libs/core-rest-api/core/src/domains/appointment/use-cases/update-appointment-info/update-appointment-info.service.ts
+++ b/libs/core-rest-api/core/src/domains/appointment/use-cases/update-appointment-info/update-appointment-info.service.ts
@@ -1,4 +1,4 @@
-import { ConflictException } from '@nestjs/common';
+import { NotFoundException } from '@nestjs/common';
 import { plainToInstance } from 'class-transformer';
 import { APPOINTMENT_ERROR_MESSAGES } from '../../../../shared/errors/error-messages';
 import { applicationValidateOrReject } from '../../../../shared/validators/validate-or-reject';
@@ -6,33 +6,27 @@ import { AppointmentDatabaseRepository } from '../../repositories/database-repos
 import { UpdatedAppointmentInfoDto } from './update-appointment-info-dto';
 
 export class UpdateAppointmentInfoService {
-  constructor(
-    private appointmentDatabaseRepository: AppointmentDatabaseRepository
-  ) {}
+  constructor(private appointmentDatabaseRepository: AppointmentDatabaseRepository) {}
 
   async execute(newAppointmentInfo: UpdatedAppointmentInfoDto): Promise<void> {
     // Validate props types
     const updateAppointmentDtoInstance = plainToInstance(
       UpdatedAppointmentInfoDto,
-      newAppointmentInfo
+      newAppointmentInfo,
     );
 
     await applicationValidateOrReject(updateAppointmentDtoInstance);
 
     const oldAppointmentInfo =
       await this.appointmentDatabaseRepository.findSingleAppointmentById(
-        newAppointmentInfo.id
+        newAppointmentInfo.id,
       );
 
     if (!oldAppointmentInfo) {
-      throw new ConflictException(
-        APPOINTMENT_ERROR_MESSAGES['APPOINTMENT_NOT_FOUND']
-      );
+      throw new NotFoundException(APPOINTMENT_ERROR_MESSAGES['APPOINTMENT_NOT_FOUND']);
     }
 
     // Update
-    await this.appointmentDatabaseRepository.updateAppointmentInfo(
-      newAppointmentInfo
-    );
+    await this.appointmentDatabaseRepository.updateAppointmentInfo(newAppointmentInfo);
   }
 }

--- a/libs/core-rest-api/core/src/domains/appointment/use-cases/update-appointment-info/update-appointment-info.spec.ts
+++ b/libs/core-rest-api/core/src/domains/appointment/use-cases/update-appointment-info/update-appointment-info.spec.ts
@@ -1,5 +1,5 @@
 import { fakerPT_BR as faker } from '@faker-js/faker';
-import { ConflictException } from '@nestjs/common';
+import { NotFoundException } from '@nestjs/common';
 import { randomUUID } from 'crypto';
 import { APPOINTMENT_ERROR_MESSAGES } from '../../../../shared/errors/error-messages';
 import { PaymentMethod } from '../../../../shared/interfaces/payments';
@@ -31,9 +31,8 @@ describe('[appointment] Update Appointment Info Service', () => {
   });
 
   it('should update an appointment', async () => {
-    const createAppointment = await databaseRepository.createSingleAppointment(
-      fakeAppointment
-    );
+    const createAppointment =
+      await databaseRepository.createSingleAppointment(fakeAppointment);
 
     const newAppointmentInfo: UpdatedAppointmentInfoDto = {
       id: createAppointment.id,
@@ -43,7 +42,7 @@ describe('[appointment] Update Appointment Info Service', () => {
 
     await service.execute(newAppointmentInfo);
     const findAppointment = await databaseRepository.findSingleAppointmentById(
-      newAppointmentInfo.id
+      newAppointmentInfo.id,
     );
 
     expect(findAppointment).toEqual({
@@ -53,12 +52,8 @@ describe('[appointment] Update Appointment Info Service', () => {
 
     expect(findAppointment?.paid).toBe(newAppointmentInfo.paid);
 
-    expect(findAppointment?.paymentMethod).toBe(
-      newAppointmentInfo.paymentMethod
-    );
-    expect(findAppointment?.paymentMethod).not.toBe(
-      fakeAppointment.paymentMethod
-    );
+    expect(findAppointment?.paymentMethod).toBe(newAppointmentInfo.paymentMethod);
+    expect(findAppointment?.paymentMethod).not.toBe(fakeAppointment.paymentMethod);
   });
 
   it('should throw error if appointment does not exist', async () => {
@@ -69,7 +64,7 @@ describe('[appointment] Update Appointment Info Service', () => {
     };
 
     await expect(service.execute(newAppointmentInfo)).rejects.toThrow(
-      new ConflictException(APPOINTMENT_ERROR_MESSAGES['APPOINTMENT_NOT_FOUND'])
+      new NotFoundException(APPOINTMENT_ERROR_MESSAGES['APPOINTMENT_NOT_FOUND']),
     );
   });
 });

--- a/libs/core-rest-api/core/src/domains/clinic/use-cases/delete-clinic/delete-clinic.service.ts
+++ b/libs/core-rest-api/core/src/domains/clinic/use-cases/delete-clinic/delete-clinic.service.ts
@@ -1,4 +1,4 @@
-import { ConflictException } from '@nestjs/common';
+import { NotFoundException } from '@nestjs/common';
 import { CLINIC_ERROR_MESSAGES } from '../../../../shared/errors/error-messages';
 import { ClinicDatabaseRepository } from '../../repositories/database-repository';
 import { DeletedClinicInfo } from './dto';
@@ -8,12 +8,10 @@ export class DeleteClinicService {
 
   async execute(clinicId: string): Promise<DeletedClinicInfo> {
     // Validate if clinic exists in db
-    const isClinicExists = await this.clinicDatabaseRepository.findClinicById(
-      clinicId
-    );
+    const isClinicExists = await this.clinicDatabaseRepository.findClinicById(clinicId);
 
     if (!isClinicExists) {
-      throw new ConflictException(CLINIC_ERROR_MESSAGES['CLINIC_NOT_FOUND']);
+      throw new NotFoundException(CLINIC_ERROR_MESSAGES['CLINIC_NOT_FOUND']);
     }
 
     // Delete clinic

--- a/libs/core-rest-api/core/src/domains/clinic/use-cases/delete-clinic/delete-clinic.spec.ts
+++ b/libs/core-rest-api/core/src/domains/clinic/use-cases/delete-clinic/delete-clinic.spec.ts
@@ -2,7 +2,7 @@ import { fakerPT_BR as faker } from '@faker-js/faker';
 import { ClinicDatabaseRepository } from '../../repositories/database-repository';
 import { DeleteClinicService } from './delete-clinic.service';
 
-import { ConflictException } from '@nestjs/common';
+import { NotFoundException } from '@nestjs/common';
 import { randomUUID } from 'crypto';
 import { InMemoryClinicDatabaseRepository } from '../../repositories/database-in-memory-repository';
 
@@ -33,8 +33,6 @@ describe('[clinic] Delete Clinic Service', () => {
   });
 
   it('should throw conflict exception if clinic do not exists', async () => {
-    await expect(service.execute(fakeClinic.name)).rejects.toThrow(
-      ConflictException
-    );
+    await expect(service.execute(fakeClinic.name)).rejects.toThrow(NotFoundException);
   });
 });

--- a/libs/core-rest-api/core/src/domains/clinic/use-cases/update-clinic/update-clinic.service.ts
+++ b/libs/core-rest-api/core/src/domains/clinic/use-cases/update-clinic/update-clinic.service.ts
@@ -1,4 +1,4 @@
-import { ConflictException } from '@nestjs/common';
+import { NotFoundException } from '@nestjs/common';
 import { plainToInstance } from 'class-transformer';
 import { CLINIC_ERROR_MESSAGES } from '../../../../shared/errors/error-messages';
 import { applicationValidateOrReject } from '../../../../shared/validators/validate-or-reject';
@@ -8,17 +8,14 @@ import { UpdateClinicDto } from './update-clinic-dto';
 export class UpdateClinicService {
   constructor(private clinicDatabaseRepository: ClinicDatabaseRepository) {}
   async execute(newClinicInfo: UpdateClinicDto): Promise<void> {
-    const updateClinicDtoInstance = plainToInstance(
-      UpdateClinicDto,
-      newClinicInfo
-    );
+    const updateClinicDtoInstance = plainToInstance(UpdateClinicDto, newClinicInfo);
     await applicationValidateOrReject(updateClinicDtoInstance);
 
     const isClinicExists = await this.clinicDatabaseRepository.findClinicById(
-      newClinicInfo.id
+      newClinicInfo.id,
     );
     if (!isClinicExists) {
-      throw new ConflictException(CLINIC_ERROR_MESSAGES['CLINIC_NOT_FOUND']);
+      throw new NotFoundException(CLINIC_ERROR_MESSAGES['CLINIC_NOT_FOUND']);
     }
 
     await this.clinicDatabaseRepository.updateClinic(newClinicInfo);

--- a/libs/core-rest-api/core/src/domains/clinic/use-cases/update-clinic/update-clinic.spec.ts
+++ b/libs/core-rest-api/core/src/domains/clinic/use-cases/update-clinic/update-clinic.spec.ts
@@ -1,5 +1,5 @@
 import { fakerPT_BR as faker } from '@faker-js/faker';
-import { ConflictException } from '@nestjs/common';
+import { NotFoundException } from '@nestjs/common';
 import { randomUUID } from 'crypto';
 import { CLINIC_ERROR_MESSAGES } from '../../../../shared/errors/error-messages';
 import { InMemoryClinicDatabaseRepository } from '../../repositories/database-in-memory-repository';
@@ -52,7 +52,7 @@ describe('[clinic] Update Clinic Service', () => {
     };
 
     await expect(service.execute(newClinicInfos)).rejects.toThrow(
-      new ConflictException(CLINIC_ERROR_MESSAGES['CLINIC_NOT_FOUND'])
+      new NotFoundException(CLINIC_ERROR_MESSAGES['CLINIC_NOT_FOUND']),
     );
   });
 });

--- a/libs/core-rest-api/core/src/domains/patient/repositories/database-in-memory-repository.ts
+++ b/libs/core-rest-api/core/src/domains/patient/repositories/database-in-memory-repository.ts
@@ -5,18 +5,14 @@ import { PatientDatabaseRepository } from '../repositories/database-repository';
 import { CreatePatientDto } from '../use-cases/create-patient/create-patient-dto';
 import { UpdatePatientDto } from '../use-cases/update-patient/update-patient-dto';
 
-export class InMemoryPatientDatabaseRepository
-  implements PatientDatabaseRepository
-{
+export class InMemoryPatientDatabaseRepository implements PatientDatabaseRepository {
   private patients: PatientEntity[] = [];
 
   async createPatient(patient: CreatePatientDto): Promise<PatientEntity> {
     const isPatientExists = await this.findPatientByEmail(patient.email);
 
     if (isPatientExists) {
-      throw new ConflictException(
-        PATIENT_ERROR_MESSAGES['CONFLICTING_CREDENTIALS']
-      );
+      throw new ConflictException(PATIENT_ERROR_MESSAGES['CONFLICTING_CREDENTIALS']);
     }
 
     const newPatient = new PatientEntity(patient);
@@ -56,13 +52,13 @@ export class InMemoryPatientDatabaseRepository
     this.patients[patientIndex] = updatedPatient;
   }
 
-  async deletePatient(email: string): Promise<void> {
-    const isPatientExists = await this.findPatientByEmail(email);
+  async deletePatient(patientId: string): Promise<void> {
+    const isPatientExists = await this.findPatientById(patientId);
 
     if (!isPatientExists) {
       throw new ConflictException(PATIENT_ERROR_MESSAGES['PATIENT_NOT_FOUND']);
     }
 
-    this.patients = this.patients.filter((patient) => patient.email !== email);
+    this.patients = this.patients.filter((patient) => patient.id !== patientId);
   }
 }

--- a/libs/core-rest-api/core/src/domains/patient/repositories/database-repository.ts
+++ b/libs/core-rest-api/core/src/domains/patient/repositories/database-repository.ts
@@ -8,5 +8,5 @@ export abstract class PatientDatabaseRepository {
   abstract findPatientById(patientId: string): Promise<PatientEntity | null>;
   abstract getPatients(): Promise<PatientEntity[]>;
   abstract updatePatient(patient: UpdatePatientDto): Promise<void>;
-  abstract deletePatient(email: string): Promise<void>;
+  abstract deletePatient(patientId: string): Promise<void>;
 }

--- a/libs/core-rest-api/core/src/domains/patient/use-cases/delete-patient/delete-patient-dto.ts
+++ b/libs/core-rest-api/core/src/domains/patient/use-cases/delete-patient/delete-patient-dto.ts
@@ -1,0 +1,9 @@
+import { IsString } from 'class-validator';
+
+export class DeletePatientDto {
+  @IsString()
+  patientId!: string;
+
+  @IsString()
+  psychologistId!: string;
+}

--- a/libs/core-rest-api/core/src/domains/patient/use-cases/delete-patient/delete-patient.service.ts
+++ b/libs/core-rest-api/core/src/domains/patient/use-cases/delete-patient/delete-patient.service.ts
@@ -1,4 +1,4 @@
-import { ConflictException } from '@nestjs/common';
+import { NotFoundException, UnauthorizedException } from '@nestjs/common';
 import { plainToInstance } from 'class-transformer';
 
 import {
@@ -24,11 +24,11 @@ export class DeletePatientService {
       await this.patientDatabaseRepository.findPatientById(patientId);
 
     if (!isPatientExists) {
-      throw new ConflictException(PATIENT_ERROR_MESSAGES['PATIENT_NOT_FOUND']);
+      throw new NotFoundException(PATIENT_ERROR_MESSAGES['PATIENT_NOT_FOUND']);
     }
 
     if (isPatientExists.psychologistId !== psychologistId) {
-      throw new ConflictException(PSYCHOLOGIST_ERROR_MESSAGES['NOT_YOUR_PATIENT']);
+      throw new UnauthorizedException(PSYCHOLOGIST_ERROR_MESSAGES['NOT_YOUR_PATIENT']);
     }
 
     // Delete patient

--- a/libs/core-rest-api/core/src/domains/patient/use-cases/delete-patient/delete-patient.service.ts
+++ b/libs/core-rest-api/core/src/domains/patient/use-cases/delete-patient/delete-patient.service.ts
@@ -1,21 +1,37 @@
-/* eslint-disable @nx/enforce-module-boundaries */
 import { ConflictException } from '@nestjs/common';
-import { PATIENT_ERROR_MESSAGES } from '../../../../shared/errors/error-messages';
+import { plainToInstance } from 'class-transformer';
+
+import {
+  PATIENT_ERROR_MESSAGES,
+  PSYCHOLOGIST_ERROR_MESSAGES,
+} from '../../../../shared/errors/error-messages';
+import { applicationValidateOrReject } from '../../../../shared/validators/validate-or-reject';
 import { PatientDatabaseRepository } from '../../repositories/database-repository';
+import { DeletePatientDto } from './delete-patient-dto';
 
 export class DeletePatientService {
   constructor(private patientDatabaseRepository: PatientDatabaseRepository) {}
 
-  async execute(email: string): Promise<void> {
+  async execute(deletePatientDto: DeletePatientDto): Promise<void> {
+    const { patientId, psychologistId } = deletePatientDto;
+
+    const createPatientDtoInstance = plainToInstance(DeletePatientDto, deletePatientDto);
+
+    await applicationValidateOrReject(createPatientDtoInstance);
+
     // Validate if patient exists in db
     const isPatientExists =
-      await this.patientDatabaseRepository.findPatientByEmail(email);
+      await this.patientDatabaseRepository.findPatientById(patientId);
 
     if (!isPatientExists) {
       throw new ConflictException(PATIENT_ERROR_MESSAGES['PATIENT_NOT_FOUND']);
     }
 
+    if (isPatientExists.psychologistId !== psychologistId) {
+      throw new ConflictException(PSYCHOLOGIST_ERROR_MESSAGES['NOT_YOUR_PATIENT']);
+    }
+
     // Delete patient
-    await this.patientDatabaseRepository.deletePatient(email);
+    await this.patientDatabaseRepository.deletePatient(patientId);
   }
 }

--- a/libs/core-rest-api/core/src/domains/patient/use-cases/delete-patient/delete-patient.spec.ts
+++ b/libs/core-rest-api/core/src/domains/patient/use-cases/delete-patient/delete-patient.spec.ts
@@ -2,8 +2,10 @@ import { fakerPT_BR as faker } from '@faker-js/faker';
 import { ConflictException } from '@nestjs/common';
 import { randomUUID } from 'crypto';
 import { PaymentMethod } from '../../../../shared/interfaces/payments';
+import { PatientEntity } from '../../entities/patient/entity';
 import { InMemoryPatientDatabaseRepository } from '../../repositories/database-in-memory-repository';
 import { PatientDatabaseRepository } from '../../repositories/database-repository';
+import { DeletePatientDto } from './delete-patient-dto';
 import { DeletePatientService } from './delete-patient.service';
 
 describe('[patient] Delete Patient Service', () => {
@@ -20,22 +22,30 @@ describe('[patient] Delete Patient Service', () => {
   let service: DeletePatientService;
   let databaseRepository: PatientDatabaseRepository;
 
-  beforeEach(async () => {
+  let patient: PatientEntity;
+  let deletePatientDto: DeletePatientDto;
+
+  beforeAll(async () => {
     databaseRepository = new InMemoryPatientDatabaseRepository();
     service = new DeletePatientService(databaseRepository);
+
+    const patient = await databaseRepository.createPatient(fakePatient);
+
+    deletePatientDto = {
+      patientId: patient.id,
+      psychologistId: patient.psychologistId,
+    };
   });
 
   it('should delete a new patient', async () => {
-    const createPatient = await databaseRepository.createPatient(fakePatient);
-
-    await service.execute(createPatient.email);
+    await service.execute(deletePatientDto);
 
     const getPatients = await databaseRepository.getPatients();
 
-    expect(getPatients).not.toContain(createPatient);
+    expect(getPatients).not.toContain(patient);
   });
 
   it('should throw conflict exception if patient do not exist', async () => {
-    await expect(service.execute(fakePatient.email)).rejects.toThrow(ConflictException);
+    await expect(service.execute(deletePatientDto)).rejects.toThrow(ConflictException);
   });
 });

--- a/libs/core-rest-api/core/src/domains/patient/use-cases/update-patient/update-patient.service.ts
+++ b/libs/core-rest-api/core/src/domains/patient/use-cases/update-patient/update-patient.service.ts
@@ -1,4 +1,4 @@
-import { ConflictException } from '@nestjs/common';
+import { NotFoundException } from '@nestjs/common';
 import { plainToInstance } from 'class-transformer';
 import { PATIENT_ERROR_MESSAGES } from '../../../../shared/errors/error-messages';
 import { applicationValidateOrReject } from '../../../../shared/validators/validate-or-reject';
@@ -10,20 +10,18 @@ export class UpdatePatientService {
 
   async execute(newPatientInfo: UpdatePatientDto): Promise<void> {
     // Validate props types
-    const updatePatientDtoInstance = plainToInstance(
-      UpdatePatientDto,
-      newPatientInfo
-    );
+    const updatePatientDtoInstance = plainToInstance(UpdatePatientDto, newPatientInfo);
 
     await applicationValidateOrReject(updatePatientDtoInstance);
 
     // Check if patient exists
-    const isPatientExists =
-      await this.patientDatabaseRepository.findPatientById(newPatientInfo.id);
+    const isPatientExists = await this.patientDatabaseRepository.findPatientById(
+      newPatientInfo.id,
+    );
 
     // If not exists, throw error
     if (!isPatientExists) {
-      throw new ConflictException(PATIENT_ERROR_MESSAGES['PATIENT_NOT_FOUND']);
+      throw new NotFoundException(PATIENT_ERROR_MESSAGES['PATIENT_NOT_FOUND']);
     }
 
     // Create

--- a/libs/core-rest-api/core/src/domains/patient/use-cases/update-patient/update-patient.spec.ts
+++ b/libs/core-rest-api/core/src/domains/patient/use-cases/update-patient/update-patient.spec.ts
@@ -1,5 +1,5 @@
 import { fakerPT_BR as faker } from '@faker-js/faker';
-import { ConflictException } from '@nestjs/common';
+import { NotFoundException } from '@nestjs/common';
 import { randomUUID } from 'crypto';
 import { PATIENT_ERROR_MESSAGES } from '../../../../shared/errors/error-messages';
 import { PaymentMethod } from '../../../../shared/interfaces/payments';
@@ -65,7 +65,7 @@ describe('[patient] Update Patient Service', () => {
     };
 
     await expect(service.execute(newPatientInfos)).rejects.toThrow(
-      new ConflictException(PATIENT_ERROR_MESSAGES['PATIENT_NOT_FOUND']),
+      new NotFoundException(PATIENT_ERROR_MESSAGES['PATIENT_NOT_FOUND']),
     );
   });
 });

--- a/libs/core-rest-api/core/src/domains/psychologist/use-cases/delete-psychologist/delete-psychologist.service.ts
+++ b/libs/core-rest-api/core/src/domains/psychologist/use-cases/delete-psychologist/delete-psychologist.service.ts
@@ -1,4 +1,4 @@
-import { ConflictException } from '@nestjs/common';
+import { NotFoundException } from '@nestjs/common';
 import { PSYCHOLOGIST_ERROR_MESSAGES } from '../../../../shared/errors/error-messages';
 import { PsychologistDatabaseRepository } from '../../repositories/database-repository';
 import { DeletedPsychologistInfo } from './dto';
@@ -12,7 +12,7 @@ export class DeletePsychologistService {
       await this.psychologistDatabaseRepository.findPsychologistByEmail(email);
 
     if (!isPsychologistExists) {
-      throw new ConflictException(PSYCHOLOGIST_ERROR_MESSAGES['PSYCHOLOGIST_NOT_FOUND']);
+      throw new NotFoundException(PSYCHOLOGIST_ERROR_MESSAGES['PSYCHOLOGIST_NOT_FOUND']);
     }
 
     // Delete psychologist

--- a/libs/core-rest-api/core/src/domains/psychologist/use-cases/delete-psychologist/delete-psychologist.spec.ts
+++ b/libs/core-rest-api/core/src/domains/psychologist/use-cases/delete-psychologist/delete-psychologist.spec.ts
@@ -1,5 +1,5 @@
 import { fakerPT_BR as faker } from '@faker-js/faker';
-import { ConflictException } from '@nestjs/common';
+import { NotFoundException } from '@nestjs/common';
 import { PSYCHOLOGIST_ERROR_MESSAGES } from '../../../../shared/errors/error-messages';
 import { Plan, Role } from '../../../../shared/interfaces/payments';
 import { InMemoryClinicDatabaseRepository } from '../../../clinic/repositories/database-in-memory-repository';
@@ -24,15 +24,14 @@ describe('[psychologist] Delete Psychologist Service', () => {
   beforeEach(async () => {
     clinicDatabaseRepository = new InMemoryClinicDatabaseRepository();
     psychologistDatabaseRepository = new InMemoryPsychologistDatabaseRepository(
-      clinicDatabaseRepository
+      clinicDatabaseRepository,
     );
     service = new DeletePsychologistService(psychologistDatabaseRepository);
   });
 
   it('should delete a new psychologist', async () => {
-    const createPsychologist = await psychologistDatabaseRepository.createPsychologist(
-      fakePsychologist
-    );
+    const createPsychologist =
+      await psychologistDatabaseRepository.createPsychologist(fakePsychologist);
     await service.execute(createPsychologist.email);
     const getPsychologists = await psychologistDatabaseRepository.getPsychologists();
 
@@ -41,7 +40,7 @@ describe('[psychologist] Delete Psychologist Service', () => {
 
   it('should throw error if psychologist does not exist', async () => {
     await expect(service.execute(fakePsychologist.email)).rejects.toThrow(
-      new ConflictException(PSYCHOLOGIST_ERROR_MESSAGES['PSYCHOLOGIST_NOT_FOUND'])
+      new NotFoundException(PSYCHOLOGIST_ERROR_MESSAGES['PSYCHOLOGIST_NOT_FOUND']),
     );
   });
 });

--- a/libs/core-rest-api/core/src/domains/psychologist/use-cases/update-psychologist/update-psychologist.service.ts
+++ b/libs/core-rest-api/core/src/domains/psychologist/use-cases/update-psychologist/update-psychologist.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, ConflictException } from '@nestjs/common';
+import { ConflictException, NotFoundException } from '@nestjs/common';
 import { plainToInstance } from 'class-transformer';
 
 import { BcryptHasherService } from '../../../../shared/cryptography/use-cases/bcrypt-hasher.service';
@@ -16,21 +16,19 @@ export class UpdatePsychologistService {
     // Validate
     const updatePsychologistDtoInstance = plainToInstance(
       UpdatePsychologistDto,
-      updatePsychologist
+      updatePsychologist,
     );
     await applicationValidateOrReject(updatePsychologistDtoInstance);
 
     // Check if psychologist exists
     const isPsychologistExists =
       await this.psychologistDatabaseRepository.findPsychologistById(
-        updatePsychologist.id
+        updatePsychologist.id,
       );
 
     // If not exists, throw error
     if (!isPsychologistExists) {
-      throw new BadRequestException(
-        PSYCHOLOGIST_ERROR_MESSAGES['PSYCHOLOGIST_NOT_FOUND']
-      );
+      throw new NotFoundException(PSYCHOLOGIST_ERROR_MESSAGES['PSYCHOLOGIST_NOT_FOUND']);
     }
 
     if (updatePsychologist.email === isPsychologistExists.email) {
@@ -44,7 +42,7 @@ export class UpdatePsychologistService {
     ) {
       const isEmailAlreadyInUse =
         await this.psychologistDatabaseRepository.findPsychologistByEmail(
-          updatePsychologist.email
+          updatePsychologist.email,
         );
 
       if (isEmailAlreadyInUse) {
@@ -56,7 +54,7 @@ export class UpdatePsychologistService {
     if (updatePsychologist.password) {
       const isPasswordTheSame = await this.hasherService.compare(
         updatePsychologist.password,
-        isPsychologistExists.password
+        isPsychologistExists.password,
       );
 
       if (isPasswordTheSame) {

--- a/libs/core-rest-api/core/src/domains/psychologist/use-cases/update-psychologist/update-psychologist.spec.ts
+++ b/libs/core-rest-api/core/src/domains/psychologist/use-cases/update-psychologist/update-psychologist.spec.ts
@@ -1,5 +1,5 @@
 import { fakerPT_BR as faker } from '@faker-js/faker';
-import { BadRequestException, ConflictException } from '@nestjs/common';
+import { ConflictException, NotFoundException } from '@nestjs/common';
 
 import { BcryptHasherService } from '../../../../shared/cryptography/use-cases/bcrypt-hasher.service';
 import { PSYCHOLOGIST_ERROR_MESSAGES } from '../../../../shared/errors/error-messages';
@@ -31,7 +31,7 @@ describe('[psychologist] Update Psychologist Service', () => {
   beforeAll(async () => {
     clinicDatabaseRepository = new InMemoryClinicDatabaseRepository();
     databaseRepository = new InMemoryPsychologistDatabaseRepository(
-      clinicDatabaseRepository
+      clinicDatabaseRepository,
     );
     service = new UpdatePsychologistService(databaseRepository);
     hasherService = new BcryptHasherService();
@@ -59,7 +59,7 @@ describe('[psychologist] Update Psychologist Service', () => {
     await service.execute(newPsychologistInfos);
 
     const findPsychologist = await databaseRepository.findPsychologistById(
-      psychologist.id
+      psychologist.id,
     );
 
     expect(findPsychologist).toEqual({
@@ -87,7 +87,7 @@ describe('[psychologist] Update Psychologist Service', () => {
     };
 
     await expect(service.execute(newPsychologistInfos)).rejects.toThrow(
-      new BadRequestException(PSYCHOLOGIST_ERROR_MESSAGES['PSYCHOLOGIST_NOT_FOUND'])
+      new NotFoundException(PSYCHOLOGIST_ERROR_MESSAGES['PSYCHOLOGIST_NOT_FOUND']),
     );
   });
 
@@ -99,7 +99,7 @@ describe('[psychologist] Update Psychologist Service', () => {
     };
 
     await expect(service.execute(newPsychologistInfos)).rejects.toThrow(
-      new ConflictException(PSYCHOLOGIST_ERROR_MESSAGES['SAME_EMAIL'])
+      new ConflictException(PSYCHOLOGIST_ERROR_MESSAGES['SAME_EMAIL']),
     );
   });
 
@@ -113,7 +113,7 @@ describe('[psychologist] Update Psychologist Service', () => {
     };
 
     await expect(service.execute(newPsychologistInfos)).rejects.toThrow(
-      new ConflictException(PSYCHOLOGIST_ERROR_MESSAGES['SAME_PASSWORD'])
+      new ConflictException(PSYCHOLOGIST_ERROR_MESSAGES['SAME_PASSWORD']),
     );
   });
 
@@ -135,7 +135,7 @@ describe('[psychologist] Update Psychologist Service', () => {
     };
 
     await expect(service.execute(newPsychologistInfos)).rejects.toThrow(
-      new ConflictException(PSYCHOLOGIST_ERROR_MESSAGES['CONFLICTING_EMAIL'])
+      new ConflictException(PSYCHOLOGIST_ERROR_MESSAGES['CONFLICTING_EMAIL']),
     );
   });
 });

--- a/libs/core-rest-api/core/src/shared/errors/error-messages.ts
+++ b/libs/core-rest-api/core/src/shared/errors/error-messages.ts
@@ -6,7 +6,7 @@ export const PSYCHOLOGIST_ERROR_MESSAGES = {
   INVALID_CREDENTIALS: 'invalid credentials',
   SAME_PASSWORD: 'new password must be different from the old one',
   SAME_EMAIL: 'new email must be different from the old one',
-  NOT_YOUR_PATIENT: 'this patient is not yours',
+  NOT_YOUR_PATIENT: 'this patient does not belong to you',
 };
 
 export const CLINIC_ERROR_MESSAGES = {

--- a/libs/core-rest-api/core/src/shared/errors/error-messages.ts
+++ b/libs/core-rest-api/core/src/shared/errors/error-messages.ts
@@ -6,6 +6,7 @@ export const PSYCHOLOGIST_ERROR_MESSAGES = {
   INVALID_CREDENTIALS: 'invalid credentials',
   SAME_PASSWORD: 'new password must be different from the old one',
   SAME_EMAIL: 'new email must be different from the old one',
+  NOT_YOUR_PATIENT: 'this patient is not yours',
 };
 
 export const CLINIC_ERROR_MESSAGES = {

--- a/libs/core-rest-api/core/src/shared/errors/globalAppHttpException.ts
+++ b/libs/core-rest-api/core/src/shared/errors/globalAppHttpException.ts
@@ -18,7 +18,7 @@ export class GlobalAppHttpException {
      * @see https://youtu.be/xdQkEn3mx1k?t=114
      */
     if (error instanceof HttpException) {
-      const exceptionMessage = message || error.message;
+      const exceptionMessage = message ?? error.message;
       const exceptionStatus = status || error.getStatus();
       Logger.warn(exceptionMessage);
       throw new HttpException(exceptionMessage, exceptionStatus, {
@@ -28,7 +28,7 @@ export class GlobalAppHttpException {
   }
 
   bubbleUpValidationException(error: unknown, message?: string, status?: HttpStatus) {
-    const exceptionMessage = message || 'Validation failed';
+    const exceptionMessage = message ?? 'Validation failed';
     if (error instanceof ValidationException) {
       Logger.warn(exceptionMessage + JSON.stringify(error.causes), className);
       throw new HttpException(
@@ -36,7 +36,7 @@ export class GlobalAppHttpException {
           message: exceptionMessage,
           causes: error.causes,
         },
-        status || 400
+        status || 400,
       );
     }
   }

--- a/libs/core-rest-api/core/src/shared/errors/validation-exception.ts
+++ b/libs/core-rest-api/core/src/shared/errors/validation-exception.ts
@@ -4,11 +4,8 @@ import { ValidationError } from 'class-validator';
 export class ValidationException extends Error {
   causes: Array<Pick<ValidationError, 'property' | 'value' | 'constraints'>>;
 
-  constructor(
-    errors: Array<ValidationError> | ValidationError,
-    message?: string
-  ) {
-    const exceptionMessage = message || 'Validation exception.';
+  constructor(errors: Array<ValidationError> | ValidationError, message?: string) {
+    const exceptionMessage = message ?? 'Validation exception.';
     super(exceptionMessage);
 
     if (errors instanceof ValidationError) {

--- a/libs/core-rest-api/core/vite.config.ts
+++ b/libs/core-rest-api/core/vite.config.ts
@@ -3,13 +3,10 @@ import swc from 'unplugin-swc';
 import { defineConfig } from 'vite';
 import tsconfigPaths from 'vite-tsconfig-paths';
 
-import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
-
 export default defineConfig({
   cacheDir: '../../../node_modules/.vite/core-rest-api-core',
 
   plugins: [
-    nxViteTsPaths(),
     swc.vite({
       module: { type: 'es6' },
     }),


### PR DESCRIPTION
<!-- pt-BR -->

# O que foi modificado?

- Foi adicionado o endpoint do use-case de deleção de paciente
- Foi corrigido alguns code smells previamente existentes
- Foi proposto uma correção do tipo de erro lançado quando não é encontrado algo no banco de dados

### Links de referência e etapas para avaliação

- Rode o seguinte comando para subir o projeto: `pnpm run core-setup --action=migrate,generate`
- Rode o seguinte comando para rodar a aplicação: `pnpm exec nx run core-rest-api:serve`
  - Verifique se não crashou a aplicação
- Agora navegue para: `apps/core-rest-api/http`
- Se não tiver o `.env` , crie e popule com seus dados
- Acesse o arquivo: `patient-client.http`
  - Agora teste todo o fluxo de deleção de paciente
  - Testar todas as possibilidades do endpoint de deleção de paciente, testar as exceções também para avaliar os tratamentos de erro

- Rode os testes E2E e verifique que todos estão passando: `pnpm run test:e2e`
- Rode os testes UNITÁRIOS e verifique que todos estão passando: `pnpm run test:unit`

### Palavras-chave

`patient`, `endpoint`

# Por que foi modificado?

- https://github.com/ItaloRAmaral/cliniccontrol/issues/111
- Estavamos com alguns code smells
- Estavamos retornando 'conflictException' em quase todos casos de 'not found'  
