### PR TITLE
Created delete patient appointment registry endpoint

### DIFF
--- a/apps/core-rest-api/http/appointment-registry.http
+++ b/apps/core-rest-api/http/appointment-registry.http
@@ -16,10 +16,9 @@ Authorization: Bearer {{authToken}}
   "patientId": "{{$dotenv PATIENT_ID}}"
 }
 
-### Update Registry
+### delete Registry
 
-# @name update_patient_appointment_registry
-PATCH http://localhost:3333/core/appointment-registry/update HTTP/1.1
-
+# @name delete_patient_appointment_registry
+DELETE http://localhost:3333/core/appointment-registry/{{$dotenv PATIENT_APPOINTMENT_REGISTRY_ID}}/delete HTTP/1.1
 Content-Type: application/json
 Authorization: Bearer {{authToken}}

--- a/apps/core-rest-api/src/app/adapters/controllers/api/api.module.ts
+++ b/apps/core-rest-api/src/app/adapters/controllers/api/api.module.ts
@@ -27,6 +27,8 @@ import { NestjsDeleteClinicService } from './use-cases/clinic/delete-clinic/nest
 import { NestjsUpdateClinicService } from './use-cases/clinic/update-clinic/nestjs-update-clinic.service';
 import { CreatePatientAppointmentRegistryController } from './use-cases/patient-appointment-registry/create-patient-appointment-registry/create-patient-appointment-registry.controller';
 import { NestjsCreatePatientAppointmentRegistryService } from './use-cases/patient-appointment-registry/create-patient-appointment-registry/nestjs-create-patient-appointment-registry.service';
+import { DeletePatientAppointmentRegistryController } from './use-cases/patient-appointment-registry/delete-patient-appointment-registry/delete-patient-appointment-registry.controller';
+import { NestjsDeletePatientAppointmentRegistryService } from './use-cases/patient-appointment-registry/delete-patient-appointment-registry/nestjs-delete-patient-appointment-registry.service';
 import { NestjsCreatePatientService } from './use-cases/patient/create-patient/nestjs-create-patient.service';
 import { NestjsDeletePatientService } from './use-cases/patient/delete-patient/nestjs-delete-patient.service';
 import { NestjsAuthenticatePsychologistService } from './use-cases/psychologist/authenticate-psychologist/nestjs-authenticate-psychologist.service';
@@ -56,7 +58,8 @@ import { NestjsUpdatePsychologistService } from './use-cases/psychologist/update
     CreatePatientController,
     DeletePatientController,
     CreatePatientAppointmentRegistryController,
-    CreateAppointmentController
+    CreateAppointmentController,
+    DeletePatientAppointmentRegistryController,
   ],
   providers: [
     BcryptHasherService,
@@ -71,7 +74,8 @@ import { NestjsUpdatePsychologistService } from './use-cases/psychologist/update
     NestjsCreatePatientService,
     NestjsDeletePatientService,
     NestjsCreatePatientAppointmentRegistryService,
-    NestjsCreateAppointmentService
+    NestjsCreateAppointmentService,
+    NestjsDeletePatientAppointmentRegistryService,
   ],
 })
 export class ApiModule {}

--- a/apps/core-rest-api/src/app/adapters/controllers/api/use-cases/patient-appointment-registry/delete-patient-appointment-registry/delete-patient-appointment-registry.controller.ts
+++ b/apps/core-rest-api/src/app/adapters/controllers/api/use-cases/patient-appointment-registry/delete-patient-appointment-registry/delete-patient-appointment-registry.controller.ts
@@ -1,0 +1,32 @@
+import { Controller, Delete, Param } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { GlobalAppHttpException } from '../../../../../../shared/errors/globalAppHttpException';
+import {
+  DeletePatientAppointmentRegistryInputDto,
+  DeletePatientAppointmentRegistryOutputDto,
+} from './dto';
+import { NestjsDeletePatientAppointmentRegistryService } from './nestjs-delete-patient-appointment-registry.service';
+
+@ApiTags('Delete Patient Appointment Registry')
+@Controller({
+  path: 'appointment-registry',
+})
+export class DeletePatientAppointmentRegistryController {
+  constructor(
+    private deletePatientAppointmentRegistryService: NestjsDeletePatientAppointmentRegistryService,
+  ) {}
+
+  @Delete(':id/delete')
+  async execute(
+    @Param()
+    { id }: DeletePatientAppointmentRegistryInputDto,
+  ): Promise<DeletePatientAppointmentRegistryOutputDto> {
+    try {
+      await this.deletePatientAppointmentRegistryService.execute({ id });
+
+      return { message: 'Appointment registry deleted successfully' };
+    } catch (error: unknown) {
+      throw new GlobalAppHttpException(error);
+    }
+  }
+}

--- a/apps/core-rest-api/src/app/adapters/controllers/api/use-cases/patient-appointment-registry/delete-patient-appointment-registry/delete-patient-appointment-registry.e2e-spec.ts
+++ b/apps/core-rest-api/src/app/adapters/controllers/api/use-cases/patient-appointment-registry/delete-patient-appointment-registry/delete-patient-appointment-registry.e2e-spec.ts
@@ -5,7 +5,7 @@ import { INestApplication } from '@nestjs/common';
 import { setupE2ETest } from '../../../../../../../../tests/utils/e2e-tests-initial-setup';
 import { PatientAppointmentRegistryEntity } from '../../../../../../core/domains/patient-appointment-registry/entities/registry/entity';
 
-describe.only('[E2E] -  Delete Appointment Registry', () => {
+describe('[E2E] -  Delete Appointment Registry', () => {
   let app: INestApplication;
 
   let access_token: string;

--- a/apps/core-rest-api/src/app/adapters/controllers/api/use-cases/patient-appointment-registry/delete-patient-appointment-registry/delete-patient-appointment-registry.e2e-spec.ts
+++ b/apps/core-rest-api/src/app/adapters/controllers/api/use-cases/patient-appointment-registry/delete-patient-appointment-registry/delete-patient-appointment-registry.e2e-spec.ts
@@ -1,0 +1,53 @@
+import request from 'supertest';
+
+import { INestApplication } from '@nestjs/common';
+
+import { setupE2ETest } from '../../../../../../../../tests/utils/e2e-tests-initial-setup';
+import { PatientAppointmentRegistryEntity } from '../../../../../../core/domains/patient-appointment-registry/entities/registry/entity';
+
+describe.only('[E2E] -  Delete Appointment Registry', () => {
+  let app: INestApplication;
+
+  let access_token: string;
+
+  let patientAppointmentRegistry: PatientAppointmentRegistryEntity;
+
+  beforeAll(async () => {
+    const setup = await setupE2ETest();
+
+    app = setup.app;
+
+    access_token = setup.access_token;
+
+    patientAppointmentRegistry = setup.patientAppointmentRegistry;
+  });
+
+  it('should delete a patient appointment registry', async () => {
+    const response = await request(app.getHttpServer())
+      .delete(`/appointment-registry/${patientAppointmentRegistry.id}/delete`)
+      .set('Authorization', `Bearer ${access_token}`);
+
+    expect(response.status).toEqual(200);
+    expect(response.body).toEqual({
+      message: 'Appointment registry deleted successfully',
+    });
+  });
+
+  it('should return 404 if the appointment registry does not exist', async () => {
+    const response = await request(app.getHttpServer())
+      .delete(`/appointment-registry/${patientAppointmentRegistry.id}/delete`)
+      .set('Authorization', `Bearer ${access_token}`);
+
+    expect(response.status).toEqual(404);
+    expect(response.body.message).toEqual('registry not found');
+  });
+
+  it('should return 401 if the user is not authenticated', async () => {
+    const response = await request(app.getHttpServer()).delete(
+      `/appointment-registry/${patientAppointmentRegistry.id}/delete`,
+    );
+
+    expect(response.status).toEqual(401);
+    expect(response.body.message).toEqual('Invalid JWT token');
+  });
+});

--- a/apps/core-rest-api/src/app/adapters/controllers/api/use-cases/patient-appointment-registry/delete-patient-appointment-registry/dto.ts
+++ b/apps/core-rest-api/src/app/adapters/controllers/api/use-cases/patient-appointment-registry/delete-patient-appointment-registry/dto.ts
@@ -1,0 +1,11 @@
+import { IsString } from 'class-validator';
+
+export class DeletePatientAppointmentRegistryInputDto {
+  @IsString()
+  id!: string;
+}
+
+export class DeletePatientAppointmentRegistryOutputDto {
+  @IsString()
+  message!: string;
+}

--- a/apps/core-rest-api/src/app/adapters/controllers/api/use-cases/patient-appointment-registry/delete-patient-appointment-registry/nestjs-delete-patient-appointment-registry.service.ts
+++ b/apps/core-rest-api/src/app/adapters/controllers/api/use-cases/patient-appointment-registry/delete-patient-appointment-registry/nestjs-delete-patient-appointment-registry.service.ts
@@ -1,0 +1,12 @@
+import { Injectable } from '@nestjs/common';
+import { PatientAppointmentRegistryDatabaseRepository } from '../../../../../../core/domains/patient-appointment-registry/repositories/database-repository';
+import { DeletePatientAppointmentRegistryService } from '../../../../../../core/domains/patient-appointment-registry/use-cases/delete-appointment-registry/delete-appointment-registry.service';
+
+@Injectable()
+export class NestjsDeletePatientAppointmentRegistryService extends DeletePatientAppointmentRegistryService {
+  constructor(
+    patientAppointmentRegistryDatabaseRepository: PatientAppointmentRegistryDatabaseRepository,
+  ) {
+    super(patientAppointmentRegistryDatabaseRepository);
+  }
+}

--- a/apps/core-rest-api/src/app/adapters/database/mappers/postgres-prisma-registry-mapper.ts
+++ b/apps/core-rest-api/src/app/adapters/database/mappers/postgres-prisma-registry-mapper.ts
@@ -1,35 +1,48 @@
-import { Prisma, PatientAppointmentRegistry as PrismaPatientAppointmentRegistryDto } from '@prisma/client';
+import {
+  Prisma,
+  PatientAppointmentRegistry as PrismaPatientAppointmentRegistryDto,
+} from '@prisma/client';
 import { Registry } from '../../../core/domains/patient-appointment-registry/entities/registry/dto';
 import { PatientAppointmentRegistryEntity } from '../../../core/domains/patient-appointment-registry/entities/registry/entity';
 import { CreatePatientAppointmentRegistryDto } from '../../../core/domains/patient-appointment-registry/use-cases/create-appointment-registry/create-appointment-registry-dto';
 import { UpdatePatientAppointmentRegistryDto } from '../../../core/domains/patient-appointment-registry/use-cases/update-appointment-registry/update-appointment-registry-dto';
 
 export class PostgresqlPrismaPatientAppointmentRegistryMapper {
-  static toDomain(raw: PrismaPatientAppointmentRegistryDto): PatientAppointmentRegistryEntity {
+  static toDomain(
+    raw: PrismaPatientAppointmentRegistryDto,
+  ): PatientAppointmentRegistryEntity {
     return new PatientAppointmentRegistryEntity({
       ...raw,
-      registry: raw.registry as unknown as Registry
+      registry: raw.registry as unknown as Registry,
     });
   }
 
-  static toDomainMany(raw: PrismaPatientAppointmentRegistryDto[]): PatientAppointmentRegistryEntity[] {
-    return raw.map((patientAppointmentRegistry) => this.toDomain(patientAppointmentRegistry))
+  static toDomainMany(
+    raw: PrismaPatientAppointmentRegistryDto[],
+  ): PatientAppointmentRegistryEntity[] {
+    return raw.map((patientAppointmentRegistry) =>
+      this.toDomain(patientAppointmentRegistry),
+    );
   }
 
-  static toPrismaCreate(raw: CreatePatientAppointmentRegistryDto): Prisma.PatientAppointmentRegistryCreateArgs {
+  static toPrismaCreate(
+    raw: CreatePatientAppointmentRegistryDto,
+  ): Prisma.PatientAppointmentRegistryCreateArgs {
     return {
       data: {
         ...raw,
-        registry: raw.registry as object
-      }
+        registry: raw.registry as object,
+      },
     };
   }
 
-  static toPrismaUpdate(raw: UpdatePatientAppointmentRegistryDto): Prisma.PatientAppointmentRegistryUpdateArgs {
+  static toPrismaUpdate(
+    raw: UpdatePatientAppointmentRegistryDto,
+  ): Prisma.PatientAppointmentRegistryUpdateArgs {
     return {
       data: {
         ...raw,
-        registry: raw.registry as object
+        registry: raw.registry as object,
       },
       where: {
         id: raw.id,

--- a/apps/core-rest-api/src/app/adapters/database/mappers/postgresql-prisma-appointment-mapper.ts
+++ b/apps/core-rest-api/src/app/adapters/database/mappers/postgresql-prisma-appointment-mapper.ts
@@ -14,7 +14,6 @@ export class PostgresqlPrismaAppointmentMapper {
     return new AppointmentEntity({
       ...raw,
       paymentMethod: raw.paymentMethod as unknown as PaymentMethod,
-      date: (raw.date).toString()
     });
   }
 
@@ -23,7 +22,7 @@ export class PostgresqlPrismaAppointmentMapper {
       data: {
         ...raw,
         paymentMethod: raw.paymentMethod as unknown as PrismaPaymentMethod,
-        date: new Date(raw.date)
+        date: new Date(raw.date),
       },
     };
   }
@@ -32,7 +31,7 @@ export class PostgresqlPrismaAppointmentMapper {
     return {
       data: {
         ...raw,
-        done: raw.done as boolean
+        done: raw.done as boolean,
       },
       where: {
         id: raw.id,

--- a/apps/core-rest-api/tests/factories/make-clinic.ts
+++ b/apps/core-rest-api/tests/factories/make-clinic.ts
@@ -11,7 +11,7 @@ import { CreateClinicDto } from '../../src/app/core/domains/clinic/use-cases/cre
 */
 export function makeClinic(
   psychologistId?: string,
-  override: Partial<CreateClinicDto> = {}
+  override: Partial<CreateClinicDto> = {},
 ): ClinicEntity {
   const newClinic = new ClinicEntity({
     name: faker.word.noun(),
@@ -35,7 +35,8 @@ export class ClinicFactory {
     const newPrismaClinic = makeClinic(clinic.psychologistId, clinic);
 
     await this.postgreSqlPrismaOrmService['clinic'].create(
-      PostgresqlPrismaClinicMapper.toPrismaCreate(newPrismaClinic)
+      // PostgresqlPrismaClinicMapper.toPrismaCreate(newPrismaClinic)
+      PostgresqlPrismaClinicMapper.toPrismaCreate(newPrismaClinic),
     );
 
     return newPrismaClinic;

--- a/apps/core-rest-api/tests/factories/make-patient-appointment-registry.ts
+++ b/apps/core-rest-api/tests/factories/make-patient-appointment-registry.ts
@@ -1,0 +1,47 @@
+import { faker } from '@faker-js/faker';
+import { Injectable } from '@nestjs/common';
+
+import { PostgreSqlPrismaOrmService } from '../../src/app/adapters/database/infra/prisma/prisma.service';
+import { PatientAppointmentRegistryEntity } from '../../src/app/core/domains/patient-appointment-registry/entities/registry/entity';
+import { CreatePatientAppointmentRegistryDto } from '../../src/app/core/domains/patient-appointment-registry/use-cases/create-appointment-registry/create-appointment-registry-dto';
+
+export function makePatientAppointmentRegistry(
+  override: Partial<CreatePatientAppointmentRegistryDto> = {},
+): PatientAppointmentRegistryEntity {
+  const newAppointment = new PatientAppointmentRegistryEntity({
+    psychologistId: faker.string.uuid(),
+    patientId: faker.string.uuid(),
+    registry: {
+      observations: faker.lorem.paragraph(),
+    },
+    ...override,
+  });
+
+  return newAppointment;
+}
+
+@Injectable()
+export class PatientAppointmentRegistryFactory {
+  constructor(private postgreSqlPrismaOrmService: PostgreSqlPrismaOrmService) {}
+
+  async makePrismaPatientAppointmentRegistry(
+    patientAppointmentRegistry: Partial<CreatePatientAppointmentRegistryDto> = {},
+  ): Promise<PatientAppointmentRegistryEntity> {
+    const newPrismaPatientAppointmentRegistry = makePatientAppointmentRegistry(
+      patientAppointmentRegistry,
+    );
+
+    await this.postgreSqlPrismaOrmService['patientAppointmentRegistry'].create({
+      data: {
+        id: newPrismaPatientAppointmentRegistry.id,
+        patientId: newPrismaPatientAppointmentRegistry.patientId,
+        psychologistId: newPrismaPatientAppointmentRegistry.psychologistId,
+        registry: {
+          observations: newPrismaPatientAppointmentRegistry.registry.observations,
+        },
+      },
+    });
+
+    return newPrismaPatientAppointmentRegistry;
+  }
+}

--- a/apps/core-rest-api/tests/utils/e2e-tests-initial-setup.ts
+++ b/apps/core-rest-api/tests/utils/e2e-tests-initial-setup.ts
@@ -10,12 +10,18 @@ import { DatabaseRepositoriesModule } from '../../src/app/adapters/database/repo
 
 import { ClinicFactory } from '../factories/make-clinic';
 import { PatientFactory } from '../factories/make-patient';
+import { PatientAppointmentRegistryFactory } from '../factories/make-patient-appointment-registry';
 import { PsychologistFactory } from '../factories/make-psychologist';
 
 export async function setupE2ETest() {
   const moduleRef: TestingModule = await Test.createTestingModule({
     imports: [ApiModule, DatabaseRepositoriesModule],
-    providers: [PsychologistFactory, ClinicFactory, PatientFactory],
+    providers: [
+      PsychologistFactory,
+      ClinicFactory,
+      PatientFactory,
+      PatientAppointmentRegistryFactory,
+    ],
   }).compile();
 
   const app: INestApplication = moduleRef.createNestApplication();
@@ -25,6 +31,8 @@ export async function setupE2ETest() {
   const clinicFactory: ClinicFactory = moduleRef.get(ClinicFactory);
   const psychologistFactory: PsychologistFactory = moduleRef.get(PsychologistFactory);
   const patientFactory: PatientFactory = moduleRef.get(PatientFactory);
+  const patientAppointmentRegistryFactory: PatientAppointmentRegistryFactory =
+    moduleRef.get(PatientAppointmentRegistryFactory);
 
   const jwt: JwtService = moduleRef.get(JwtService);
 
@@ -67,6 +75,14 @@ export async function setupE2ETest() {
     clinicId: clinic.id,
   });
 
+  // Creating a patient appointment registry to use in tests
+  const patientAppointmentRegistry =
+    await patientAppointmentRegistryFactory.makePrismaPatientAppointmentRegistry({
+      psychologistId: psychologist.id,
+      patientId: patient.id,
+      registry: { observations: 'get well' },
+    });
+
   return {
     prisma,
     app,
@@ -82,5 +98,6 @@ export async function setupE2ETest() {
     clinic,
     patientFactory,
     patient,
+    patientAppointmentRegistry,
   };
 }


### PR DESCRIPTION
<!-- pt-BR -->

# O que foi modificado?

- Adicionado um endpoint de criar consultas

### Links de referência e etapas para avaliação

- Rode o seguinte comando para subir o projeto: `pnpm run core-setup --action=migrate,generate`
- Rode o seguinte comando para rodar a aplicação: `pnpm exec nx run core-rest-api:serve`
  - Verifique se não crashou a aplicação
- Agora navegue para: `libs/core-rest-api/adapters/src/controllers/api/use-cases/patient-appointment-registry`
- Acesse o arquivo: `appointment-registry.http`
  - Agora teste todo o fluxo de de deleção de registros de consulta
  - Testar todas as possibilidades do endpoint de criação de consulta, testar as exceções também para avaliar os tratamentos de erro

### Palavras-chave

`appointment registry`, `endpoint`, `delete`

# Por que foi modificado?

- https://github.com/ItaloRAmaral/cliniccontrol/issues/125
