### PR TITLE
131 criacao de endpoint de delecao de consultas

### DIFF
--- a/apps/core-rest-api/http/appointment-client.http
+++ b/apps/core-rest-api/http/appointment-client.http
@@ -1,7 +1,6 @@
 @authToken = {{$dotenv AUTH_TOKEN}}
 @apiKey = {{$dotenv API_KEY}}
 
-# @appointmentDate = {{require "./appointmentDate.js"}}
 ####
 
 # @name create_appointment
@@ -19,3 +18,11 @@ Authorization: Bearer {{authToken}}
   "cancelled": false,
   "date": "2024-01-19T08:30:54"
 }
+
+###
+
+# @name delete_appointment
+
+DELETE http://localhost:3333/core/appointment/{{$dotenv APPOINTMENT_ID}}/delete HTTP/1.1
+Content-Type: application/json
+Authorization: Bearer {{authToken}}

--- a/apps/core-rest-api/http/initial-setup.client.http
+++ b/apps/core-rest-api/http/initial-setup.client.http
@@ -56,3 +56,21 @@ Authorization: Bearer {{authToken}}
   "clinicId": "{{$dotenv CLINIC_ID}}",
   "paymentMethod": "CREDIT_CARD"
 }
+
+##################################### APPOINTMENT #####################################
+
+# @name create_appointment
+POST http://localhost:3333/core/appointment/create HTTP/1.1
+Content-Type: application/json
+Authorization: Bearer {{authToken}}
+
+{
+  "psychologistId": "{{$dotenv PSYCHOLOGIST_ID}}",
+  "clinicId": "{{$dotenv CLINIC_ID}}",
+  "patientId": "{{$dotenv PATIENT_ID}}",
+  "paymentMethod": "CREDIT_CARD",
+  "online": false,
+  "confirmed": true,
+  "cancelled": false,
+  "date": "2024-01-19T08:30:54"
+}

--- a/apps/core-rest-api/src/app/adapters/controllers/api/api.module.ts
+++ b/apps/core-rest-api/src/app/adapters/controllers/api/api.module.ts
@@ -22,6 +22,8 @@ import { DeletePsychologistController } from './use-cases/psychologist/delete-ps
 
 import { CreateAppointmentController } from './use-cases/appointment/create-appointment/create-appointment.controller';
 import { NestjsCreateAppointmentService } from './use-cases/appointment/create-appointment/nestjs-create-appointment.service';
+import { DeleteAppointmentController } from './use-cases/appointment/delete-appointment/delete-appointment.controller';
+import { NestjsDeleteAppointmentService } from './use-cases/appointment/delete-appointment/nestjs-delete-appointment.service';
 import { NestjsCreateClinicService } from './use-cases/clinic/create-clinic/nestjs-create-clinic.service';
 import { NestjsDeleteClinicService } from './use-cases/clinic/delete-clinic/nestjs-delete-clinic.service';
 import { NestjsUpdateClinicService } from './use-cases/clinic/update-clinic/nestjs-update-clinic.service';
@@ -61,6 +63,7 @@ import { NestjsUpdatePsychologistService } from './use-cases/psychologist/update
     DeletePatientController,
     CreatePatientAppointmentRegistryController,
     CreateAppointmentController,
+    DeleteAppointmentController,
     DeletePatientAppointmentRegistryController,
     UpdatePatientAppointmentRegistryController
   ],
@@ -78,6 +81,7 @@ import { NestjsUpdatePsychologistService } from './use-cases/psychologist/update
     NestjsDeletePatientService,
     NestjsCreatePatientAppointmentRegistryService,
     NestjsCreateAppointmentService,
+    NestjsDeleteAppointmentService,
     NestjsDeletePatientAppointmentRegistryService,
     NestjsUpdatePatientAppointmentRegistryService
   ],

--- a/apps/core-rest-api/src/app/adapters/controllers/api/use-cases/appointment/delete-appointment/delete-appointment.controller.ts
+++ b/apps/core-rest-api/src/app/adapters/controllers/api/use-cases/appointment/delete-appointment/delete-appointment.controller.ts
@@ -1,0 +1,28 @@
+import { Controller, Delete, Param } from "@nestjs/common";
+import { ApiBearerAuth, ApiTags } from "@nestjs/swagger";
+import { GlobalAppHttpException } from '../../../../../../shared/errors/globalAppHttpException';
+import { DeleteAppointmentInputDto } from "./input.dto";
+import { NestjsDeleteAppointmentService } from "./nestjs-delete-appointment.service";
+import { DeleteAppointmentOutputDto } from "./output.dto";
+
+@ApiTags('Appointment')
+@ApiBearerAuth()
+@Controller({
+  path: 'appointment',
+})
+export class DeleteAppointmentController {
+  constructor(private deleteAppointmentService: NestjsDeleteAppointmentService) {}
+
+  @Delete(':appointmentId/delete')
+  async execute(@Param() {appointmentId}: DeleteAppointmentInputDto): Promise<DeleteAppointmentOutputDto>{
+    try {
+      await this.deleteAppointmentService.execute(appointmentId);
+
+      return {
+        message: 'Appointment deleted successfully',
+      }
+    } catch (error) {
+      throw new GlobalAppHttpException(error);
+    }
+  }
+}

--- a/apps/core-rest-api/src/app/adapters/controllers/api/use-cases/appointment/delete-appointment/delete-appointment.e2e-spec.ts
+++ b/apps/core-rest-api/src/app/adapters/controllers/api/use-cases/appointment/delete-appointment/delete-appointment.e2e-spec.ts
@@ -1,0 +1,98 @@
+import { faker } from '@faker-js/faker';
+import { INestApplication } from '@nestjs/common';
+import request from 'supertest';
+import { makeAppointment } from '../../../../../../../../tests/factories/make-appointment';
+import { setupE2ETest } from '../../../../../../../../tests/utils/e2e-tests-initial-setup';
+import { AppointmentEntity } from '../../../../../../core/domains/appointment/entities/appointment/entity';
+import { PaymentMethod } from '../../../../../../core/shared/interfaces/payments';
+import { PostgreSqlPrismaOrmService } from '../../../../../database/infra/prisma/prisma.service';
+
+describe('[E2E] - Delete Appointment', () => {
+  let prisma: PostgreSqlPrismaOrmService;
+  let app: INestApplication;
+  let access_token: string;
+  let invalid_access_token: string;
+  let appointment: AppointmentEntity;
+  let psychologistId: string;
+  let clinicId: string;
+  let patientId: string;
+
+  beforeAll(async () => {
+    const setup = await setupE2ETest();
+    prisma = setup.prisma;
+    app = setup.app;
+
+    access_token = setup.access_token;
+    invalid_access_token = setup.invalid_access_token;
+    appointment = setup.appointment
+
+    clinicId = setup.clinic.id;
+    psychologistId = setup.psychologist.id;
+    patientId = setup.patient.id;
+  });
+
+  it('[DELETE] - Should return an error when trying to delete an appointment without access_token', async () => {
+    const response = await request(app.getHttpServer()).delete(
+      `/appointment/${appointment.id}/delete`,
+    );
+
+    expect(response.status).toBe(401);
+    expect(response.body.message).toBe('Invalid JWT token');
+  });
+
+  it('[DELETE] - Should return an error when trying to delete an apppointment with invalid access_token', async () => {
+    const response = await request(app.getHttpServer())
+      .delete(`/appointment/${appointment.id}/delete`)
+      .set('Authorization', `Bearer ${invalid_access_token}`);
+
+    expect(response.status).toBe(401);
+    expect(response.body.message).toBe('Invalid JWT token');
+  });
+
+  it('[DELETE] - Should throw an error if route param is not an valid id', async () => {
+    const wrongId = faker.string.uuid();
+
+    const response = await request(app.getHttpServer())
+      .delete(`/appointment/${wrongId}/delete`)
+      .set('Authorization', `Bearer ${access_token}`);
+
+    expect(response.status).toBe(404);
+    expect(response.body.message).toBe('appointment not found');
+  });
+
+  it('[DELETE] - Should successfully delete an appointment', async () => {
+
+    console.log('psychologistId', psychologistId)
+    console.log('clinicId', clinicId)
+    console.log('patientId', patientId)
+    const newAppointment: AppointmentEntity = makeAppointment({
+      psychologistId,
+      clinicId,
+      patientId,
+      date: faker.date.recent({ days: 10 }),
+      cancelled: false,
+      confirmationDate: null,
+      confirmed: true,
+      online: false,
+      paymentMethod: PaymentMethod.CREDIT_CARD
+    });
+
+    await request(app.getHttpServer())
+      .post('/appointment/create')
+      .set('Authorization', `Bearer ${access_token}`)
+      .send(newAppointment);
+
+    const response = await request(app.getHttpServer())
+      .delete(`/appointment/${newAppointment.id}/delete`)
+      .set('Authorization', `Bearer ${access_token}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.message).toBe('Appointment deleted successfully');
+
+    const deletedAppointment = await prisma['appointment'].findUnique({
+      where: { id: newAppointment.id },
+    });
+
+    expect(deletedAppointment).toBeNull();
+  });
+});

--- a/apps/core-rest-api/src/app/adapters/controllers/api/use-cases/appointment/delete-appointment/delete-appointment.e2e-spec.ts
+++ b/apps/core-rest-api/src/app/adapters/controllers/api/use-cases/appointment/delete-appointment/delete-appointment.e2e-spec.ts
@@ -22,19 +22,31 @@ describe('[E2E] - Delete Appointment', () => {
     appointment = setup.appointment
   });
 
+  async function deleteAppointmentWithoutAcessToken (appointmentId: string) {
+    const response = await request(app.getHttpServer())
+      .delete(`/appointment/${appointmentId}/delete`)
+
+    return response
+  }
+
+  async function deleteAppointmentWithAcessToken (appointmentId: string, accessToken?: string) {
+    const response = await request(app.getHttpServer())
+      .delete(`/appointment/${appointmentId}/delete`)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    return response
+  }
+
   it('[DELETE] - Should return an error when trying to delete an appointment without access_token', async () => {
-    const response = await request(app.getHttpServer()).delete(
-      `/appointment/${appointment.id}/delete`,
-    );
+    const response = await deleteAppointmentWithoutAcessToken(appointment.id)
 
     expect(response.status).toBe(401);
     expect(response.body.message).toBe('Invalid JWT token');
   });
 
   it('[DELETE] - Should return an error when trying to delete an apppointment with invalid access_token', async () => {
-    const response = await request(app.getHttpServer())
-      .delete(`/appointment/${appointment.id}/delete`)
-      .set('Authorization', `Bearer ${invalid_access_token}`);
+    const accessToken = invalid_access_token
+    const response = await deleteAppointmentWithAcessToken(appointment.id, accessToken)
 
     expect(response.status).toBe(401);
     expect(response.body.message).toBe('Invalid JWT token');
@@ -42,19 +54,14 @@ describe('[E2E] - Delete Appointment', () => {
 
   it('[DELETE] - Should throw an error if route param is not an valid id', async () => {
     const wrongId = faker.string.uuid();
-
-    const response = await request(app.getHttpServer())
-      .delete(`/appointment/${wrongId}/delete`)
-      .set('Authorization', `Bearer ${access_token}`);
+    const response = await deleteAppointmentWithAcessToken(wrongId, access_token)
 
     expect(response.status).toBe(404);
     expect(response.body.message).toBe('appointment not found');
   });
 
   it('[DELETE] - Should successfully delete an appointment', async () => {
-    const response = await request(app.getHttpServer())
-      .delete(`/appointment/${appointment.id}/delete`)
-      .set('Authorization', `Bearer ${access_token}`);
+    const response = await deleteAppointmentWithAcessToken(appointment.id, access_token)
 
     expect(response.status).toBe(200);
     expect(response.body.message).toBe('Appointment deleted successfully');

--- a/apps/core-rest-api/src/app/adapters/controllers/api/use-cases/appointment/delete-appointment/input.dto.ts
+++ b/apps/core-rest-api/src/app/adapters/controllers/api/use-cases/appointment/delete-appointment/input.dto.ts
@@ -1,0 +1,6 @@
+import { IsString } from "class-validator";
+
+export class DeleteAppointmentInputDto {
+  @IsString()
+  appointmentId!: string;
+}

--- a/apps/core-rest-api/src/app/adapters/controllers/api/use-cases/appointment/delete-appointment/nestjs-delete-appointment.service.ts
+++ b/apps/core-rest-api/src/app/adapters/controllers/api/use-cases/appointment/delete-appointment/nestjs-delete-appointment.service.ts
@@ -1,0 +1,11 @@
+
+import { Injectable } from '@nestjs/common';
+import { AppointmentDatabaseRepository } from '../../../../../../core/domains/appointment/repositories/database-repository';
+import { DeleteSingleAppointmentService } from '../../../../../../core/domains/appointment/use-cases/delete-single-appointment/delete-single-appointment.service';
+
+@Injectable()
+export class NestjsDeleteAppointmentService extends DeleteSingleAppointmentService {
+  constructor(appointmentDatabaseRepository: AppointmentDatabaseRepository) {
+    super(appointmentDatabaseRepository);
+  }
+}

--- a/apps/core-rest-api/src/app/adapters/controllers/api/use-cases/appointment/delete-appointment/output.dto.ts
+++ b/apps/core-rest-api/src/app/adapters/controllers/api/use-cases/appointment/delete-appointment/output.dto.ts
@@ -1,0 +1,6 @@
+import { IsString } from "class-validator";
+
+export class DeleteAppointmentOutputDto {
+  @IsString()
+  message!: string;
+}

--- a/apps/core-rest-api/src/app/adapters/controllers/api/use-cases/patient-appointment-registry/delete-patient-appointment-registry/delete-patient-appointment-registry.e2e-spec.ts
+++ b/apps/core-rest-api/src/app/adapters/controllers/api/use-cases/patient-appointment-registry/delete-patient-appointment-registry/delete-patient-appointment-registry.e2e-spec.ts
@@ -4,9 +4,11 @@ import { INestApplication } from '@nestjs/common';
 
 import { setupE2ETest } from '../../../../../../../../tests/utils/e2e-tests-initial-setup';
 import { PatientAppointmentRegistryEntity } from '../../../../../../core/domains/patient-appointment-registry/entities/registry/entity';
+import { PostgreSqlPrismaOrmService } from '../../../../../database/infra/prisma/prisma.service';
 
 describe('[E2E] -  Delete Appointment Registry', () => {
   let app: INestApplication;
+  let prisma: PostgreSqlPrismaOrmService;
 
   let access_token: string;
 
@@ -16,7 +18,7 @@ describe('[E2E] -  Delete Appointment Registry', () => {
     const setup = await setupE2ETest();
 
     app = setup.app;
-
+    prisma = setup.prisma;
     access_token = setup.access_token;
 
     patientAppointmentRegistry = setup.patientAppointmentRegistry;
@@ -31,6 +33,12 @@ describe('[E2E] -  Delete Appointment Registry', () => {
     expect(response.body).toEqual({
       message: 'Appointment registry deleted successfully',
     });
+
+    const deletedPatientAppointmentRegistry = await prisma.patientAppointmentRegistry.findUnique({
+      where: { id:  patientAppointmentRegistry.id},
+    });
+    expect(deletedPatientAppointmentRegistry).toBeNull();
+
   });
 
   it('should return 404 if the appointment registry does not exist', async () => {

--- a/apps/core-rest-api/src/app/adapters/database/infra/prisma/migrations/20240226123249_test_ondelete_cascade_in_appointment/migration.sql
+++ b/apps/core-rest-api/src/app/adapters/database/infra/prisma/migrations/20240226123249_test_ondelete_cascade_in_appointment/migration.sql
@@ -1,0 +1,5 @@
+-- DropForeignKey
+ALTER TABLE "appointment" DROP CONSTRAINT "appointment_clinic_id_fkey";
+
+-- AddForeignKey
+ALTER TABLE "appointment" ADD CONSTRAINT "appointment_clinic_id_fkey" FOREIGN KEY ("clinic_id") REFERENCES "clinic"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/core-rest-api/src/app/adapters/database/infra/prisma/migrations/20240226124127_add_delete_on_cascade_in_psychologist_and_patient/migration.sql
+++ b/apps/core-rest-api/src/app/adapters/database/infra/prisma/migrations/20240226124127_add_delete_on_cascade_in_psychologist_and_patient/migration.sql
@@ -1,0 +1,11 @@
+-- DropForeignKey
+ALTER TABLE "appointment" DROP CONSTRAINT "appointment_patient_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "appointment" DROP CONSTRAINT "appointment_psychologist_id_fkey";
+
+-- AddForeignKey
+ALTER TABLE "appointment" ADD CONSTRAINT "appointment_patient_id_fkey" FOREIGN KEY ("patient_id") REFERENCES "patient"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "appointment" ADD CONSTRAINT "appointment_psychologist_id_fkey" FOREIGN KEY ("psychologist_id") REFERENCES "psychologist"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/core-rest-api/src/app/adapters/database/infra/prisma/postgresql.schema.prisma
+++ b/apps/core-rest-api/src/app/adapters/database/infra/prisma/postgresql.schema.prisma
@@ -104,11 +104,11 @@ model Appointment {
   updatedAt        DateTime      @default(now()) @map("updated_at") @db.Timestamptz(6)
 
   patientId      String       @map("patient_id")
-  patient        Patient      @relation(fields: [patientId], references: [id])
+  patient        Patient      @relation(fields: [patientId], references: [id], onDelete: Cascade)
   psychologistId String       @map("psychologist_id")
-  psychologist   Psychologist @relation(fields: [psychologistId], references: [id])
+  psychologist   Psychologist @relation(fields: [psychologistId], references: [id], onDelete: Cascade)
   clinicId       String       @map("clinic_id")
-  clinic         Clinic       @relation(fields: [clinicId], references: [id])
+  clinic         Clinic       @relation(fields: [clinicId], references: [id], onDelete: Cascade)
 
   @@map("appointment")
 }

--- a/apps/core-rest-api/src/app/core/domains/appointment/use-cases/delete-single-appointment/delete-single-appointment.service.ts
+++ b/apps/core-rest-api/src/app/core/domains/appointment/use-cases/delete-single-appointment/delete-single-appointment.service.ts
@@ -20,6 +20,6 @@ export class DeleteSingleAppointmentService {
     }
 
     // Delete
-    this.appointmentDatabaseRepository.deleteSingleAppointment(appointmentId);
+    await this.appointmentDatabaseRepository.deleteSingleAppointment(appointmentId);
   }
 }

--- a/apps/core-rest-api/tests/utils/e2e-tests-initial-setup.ts
+++ b/apps/core-rest-api/tests/utils/e2e-tests-initial-setup.ts
@@ -8,6 +8,7 @@ import { ApiModule } from '../../src/app/adapters/controllers/api/api.module';
 import { PostgreSqlPrismaOrmService } from '../../src/app/adapters/database/infra/prisma/prisma.service';
 import { DatabaseRepositoriesModule } from '../../src/app/adapters/database/repositories/repositories.module';
 
+import { AppointmentFactory } from '../factories/make-appointment';
 import { ClinicFactory } from '../factories/make-clinic';
 import { PatientFactory } from '../factories/make-patient';
 import { PatientAppointmentRegistryFactory } from '../factories/make-patient-appointment-registry';
@@ -20,6 +21,7 @@ export async function setupE2ETest() {
       PsychologistFactory,
       ClinicFactory,
       PatientFactory,
+      AppointmentFactory,
       PatientAppointmentRegistryFactory,
     ],
   }).compile();
@@ -31,6 +33,7 @@ export async function setupE2ETest() {
   const clinicFactory: ClinicFactory = moduleRef.get(ClinicFactory);
   const psychologistFactory: PsychologistFactory = moduleRef.get(PsychologistFactory);
   const patientFactory: PatientFactory = moduleRef.get(PatientFactory);
+  const appointmentFactory: AppointmentFactory = moduleRef.get(AppointmentFactory);
   const patientAppointmentRegistryFactory: PatientAppointmentRegistryFactory =
     moduleRef.get(PatientAppointmentRegistryFactory);
 
@@ -75,6 +78,19 @@ export async function setupE2ETest() {
     clinicId: clinic.id,
   });
 
+  // Creating an appointment to use in tests
+  const appointment = await appointmentFactory.makePrismaAppointment({
+    psychologistId: psychologist.id,
+    clinicId: clinic.id,
+    patientId: patient.id,
+    date: faker.date.recent({ days: 10 }),
+    cancelled: false,
+    confirmationDate: null,
+    confirmed: true,
+    online: false,
+    paymentMethod: undefined
+  });
+
   // Creating a patient appointment registry to use in tests
   const patientAppointmentRegistry =
     await patientAppointmentRegistryFactory.makePrismaPatientAppointmentRegistry({
@@ -98,6 +114,8 @@ export async function setupE2ETest() {
     clinic,
     patientFactory,
     patient,
+    appointment,
+    appointmentFactory,
     patientAppointmentRegistry,
   };
 }


### PR DESCRIPTION
<!-- pt-BR -->

# O que foi modificado?

- Adicionado um endpoint de deletar consultas

### Links de referência e etapas para avaliação

- Rode o seguinte comando para subir o projeto: `pnpm run core-setup --action=migrate,generate`
- Rode o seguinte comando para rodar a aplicação: `pnpm exec nx run core-rest-api:serve`
  - Verifique se não crashou a aplicação
- Agora navegue para: `libs/core-rest-api/adapters/src/controllers/api/use-cases/appointment`
- Acesse o arquivo: `appointment-client.http`
  - Agora teste todo o fluxo de de deleção de consulta
  - Testar todas as possibilidades do endpoint de deleção de consulta, testar as exceções também para avaliar os tratamentos de erro

### Palavras-chave

`appointment`, `endpoint`, `delete`

# Por que foi modificado?

- https://github.com/ItaloRAmaral/cliniccontrol/issues/131
